### PR TITLE
Adapt selectors for new branding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,11 @@ help: ## Display this help menu
 check:
 	npm run build
 
-test: ## Build and copy to the dependencies directory for the project 
-	rm dist -rf
+test: ## Build and copy to the dependencies directory for the project
+	rm -rf dist
 	npm run build
-	rm $(filter-out $@,$(MAKECMDGOALS))/tests/UI/node_modules/@prestashop-core/ui-testing/dist/ -r
-	cp dist $(filter-out $@,$(MAKECMDGOALS))/tests/UI/node_modules/@prestashop-core/ui-testing/ -r
+	rm -r $(filter-out $@,$(MAKECMDGOALS))/tests/UI/node_modules/@prestashop-core/ui-testing/dist/
+	cp -r dist $(filter-out $@,$(MAKECMDGOALS))/tests/UI/node_modules/@prestashop-core/ui-testing/
 	cp package.json $(filter-out $@,$(MAKECMDGOALS))/tests/UI/node_modules/@prestashop-core/ui-testing/
 
 .DEFAULT_GOAL := help

--- a/src/pages/BO/BOBasePage.ts
+++ b/src/pages/BO/BOBasePage.ts
@@ -61,6 +61,8 @@ export default class BOBasePage extends CommonPage implements BOBasePagePageInte
 
   protected readonly helpButton: string;
 
+  protected readonly closeHelpButton: string;
+
   private readonly menuMobileButton: string;
 
   private readonly notificationsLink: string;
@@ -323,6 +325,7 @@ export default class BOBasePage extends CommonPage implements BOBasePagePageInte
 
     // Header links
     this.helpButton = '#product_form_open_help';
+    this.closeHelpButton = '#right-sidebar #ps-quicknav-sidebar .quicknav-header [data-target=".sidebar"]';
     this.menuMobileButton = '.js-mobile-menu';
     this.notificationsLink = '#notification,#notif';
     this.notificationsDropDownMenu = '#notification div.dropdown-menu-right.notifs_dropdown,#notif div.dropdown-menu';
@@ -1052,7 +1055,7 @@ export default class BOBasePage extends CommonPage implements BOBasePagePageInte
    * @returns {Promise<boolean>}
    */
   async closeHelpSideBar(page: Page): Promise<boolean> {
-    await this.waitForSelectorAndClick(page, this.helpButton);
+    await this.waitForSelectorAndClick(page, this.closeHelpButton);
     return this.elementVisible(page, `${this.rightSidebar}:not(.sidebar-open)`, 2000);
   }
 

--- a/src/versions/develop/pages/BO/login/index.ts
+++ b/src/versions/develop/pages/BO/login/index.ts
@@ -59,7 +59,7 @@ class LoginPage extends BOBasePage implements LoginPageInterface {
 
     this.loginBackShopLink = '#login-panel span.login-back-shop';
     this.loginFooter = '#login-footer';
-    this.allRightsReservedLink = `${this.loginFooter} p.text-center.text-muted a`;
+    this.allRightsReservedLink = `${this.loginFooter} .text-muted a`;
     this.twitterLink = `${this.loginFooter} a.link-social.link-twitter`;
     this.facebookLink = `${this.loginFooter} a.link-social.link-facebook`;
     this.githubLink = `${this.loginFooter} a.link-social.link-github`;


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adapt selectors for new branding, and make `make test` compatible with Mac OS
| Type?             | refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Sponsor company   | ~
| How to test?      | To validate that these changes are compatible with develop branch even without the reskin a PR has been created based on this branch https://github.com/PrestaShop/PrestaShop/pull/36681 And here is the UI tests running based on these modifications https://github.com/jolelievre/ga.tests.ui.pr/actions/runs/10266090987
