### PR TITLE
`FakerSearchTag` : Use only products from last version of PrestaShop

### DIFF
--- a/src/data/demo/products.ts
+++ b/src/data/demo/products.ts
@@ -247,6 +247,7 @@ export default {
   }),
   // Products demo for PS version <= 1.7.2
   //@todo : to find for a solution in case of upgrade 1.7.2 to 1.7.8
+  //@todo : Clean FakerCartRule & FakerSearchTag
   old_demo_1: new FakerProduct({
     id: 1,
     name: 'Faded Short Sleeves T-shirt',

--- a/src/data/faker/cartRule.ts
+++ b/src/data/faker/cartRule.ts
@@ -10,7 +10,14 @@ import type {
 
 import {faker} from '@faker-js/faker';
 
-const productsNames: string[] = Object.values(dataProducts).map((product: FakerProduct) => product.name);
+const productsNames: string[] = Object.entries(dataProducts)
+  .map((value: [string, FakerProduct]) => {
+    if (value[0].startsWith('old_')) {
+      return '';
+    }
+    return value[1].name;
+  })
+  .filter((value: string) => value !== '');
 
 /**
  * Create new cart rule to use on creation cart rule form on BO

--- a/src/data/faker/searchTag.ts
+++ b/src/data/faker/searchTag.ts
@@ -6,7 +6,14 @@ import SearchTagCreator from '@data/types/searchTag';
 
 import {faker} from '@faker-js/faker';
 
-const productsNames: string[] = Object.values(dataProducts).map((product: FakerProduct) => product.name);
+const productsNames: string[] = Object.entries(dataProducts)
+  .map((value: [string, FakerProduct]) => {
+    if (value[0].startsWith('old_')) {
+      return '';
+    }
+    return value[1].name;
+  })
+  .filter((value: string) => value !== '');
 const languagesNames: string[] = Object.values(dataLanguages).map((language: FakerLanguage) => language.name);
 
 /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | `FakerSearchTag` : Use only products from last version of PrestaShop
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is :green_circle: 
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp