### PR TITLE
Fix Module Configuration Button for PS version < 1.7.4

### DIFF
--- a/src/versions/1.7.4/pages/BO/modules/modulesAndServices/installedModules.ts
+++ b/src/versions/1.7.4/pages/BO/modules/modulesAndServices/installedModules.ts
@@ -36,7 +36,7 @@ class InstalledModulesPage extends BOBasePage implements InstalledModulesPageInt
 
     // Selectors
     this.selectionLink = '#subtab-AdminModulesCatalog';
-    this.configureModuleButton = '.dropdown-menu form[action*=\'configure\']';
+    this.configureModuleButton = '.dropdown-menu form[action*=\'configure\'], .module_action_menu_configure';
     this.searchModuleTagInput = '#search-input-group input.pstaggerAddTagInput';
     this.searchModuleButton = '#module-search-button';
     this.moduleItemName = (moduleTag: string) => `.module-item-list[data-tech-name=${moduleTag}]`;

--- a/src/versions/develop/pages/BO/modules/autoupgrade/index.ts
+++ b/src/versions/develop/pages/BO/modules/autoupgrade/index.ts
@@ -226,7 +226,7 @@ class Autoupgrade extends ModuleConfiguration implements ModuleAutoupgradeMainPa
    * @return {Promise<string}
    */
   async checkUpdateSuccess(page: Page): Promise<string> {
-    await this.waitForVisibleSelector(page, this.updateProgressBar, 500000);
+    await this.waitForVisibleSelector(page, this.updateProgressBar, 1000000);
 
     return this.getTextContent(page, this.updateAlertSuccessMessage);
   }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix Module Configuration Button for PS version < 1.7.4
| Type?             | refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| Sponsor company   | @PrestaShopCore
| How to test?      | Ci is :green_apple: 
