### PR TITLE
Fix autoupgrade page title for PS 1.7.1

### DIFF
--- a/src/pages/BO/modules/autoupgrade/index.ts
+++ b/src/pages/BO/modules/autoupgrade/index.ts
@@ -6,6 +6,9 @@ const psVersion = testContext.getPSVersion();
 
 /* eslint-disable global-require, @typescript-eslint/no-require-imports */
 function requirePage(): ModuleAutoupgradeMainPageInterface {
+  if (semver.lte(psVersion, '7.1.2') && semver.gte(psVersion, '7.1.0')) {
+    return require('@versions/1.7.1/pages/BO/modules/autoupgrade').autoupgrade;
+  }
   if (semver.lt(psVersion, '7.4.0')) {
     return require('@versions/1.7.3/pages/BO/modules/autoupgrade').autoupgrade;
   }

--- a/src/versions/1.7.1/pages/BO/modules/autoupgrade/index.ts
+++ b/src/versions/1.7.1/pages/BO/modules/autoupgrade/index.ts
@@ -1,0 +1,22 @@
+import {ModuleAutoupgradeMainPageInterface} from '@interfaces/BO/modules/autoupgrade';
+import {Autoupgrade} from '@versions/1.7.3/pages/BO/modules/autoupgrade';
+
+/**
+ * Module configuration page for module : Autoupgrade, contains selectors and functions for the page
+ * @class
+ * @extends ModuleConfiguration
+ */
+class AutoupgradeVersion extends Autoupgrade implements ModuleAutoupgradeMainPageInterface {
+  /**
+   * @constructs
+   * Setting up texts and selectors to use on module configuration page
+   */
+  constructor() {
+    super();
+
+    this.pageTitle = 'AdminSelfUpgrade > AdminSelfUpgrade • PrestaShop';
+  }
+}
+
+const autoupgrade = new AutoupgradeVersion();
+export {autoupgrade, AutoupgradeVersion as Autoupgrade};

--- a/src/versions/1.7.1/pages/BO/modules/autoupgrade/index.ts
+++ b/src/versions/1.7.1/pages/BO/modules/autoupgrade/index.ts
@@ -14,7 +14,7 @@ class AutoupgradeVersion extends Autoupgrade implements ModuleAutoupgradeMainPag
   constructor() {
     super();
 
-    this.pageTitle = 'AdminSelfUpgrade > AdminSelfUpgrade • PrestaShop';
+    this.pageTitle = `AdminSelfUpgrade > AdminSelfUpgrade • ${global.INSTALL.SHOP_NAME}`;
   }
 }
 

--- a/src/versions/develop/pages/BO/modules/autoupgrade/index.ts
+++ b/src/versions/develop/pages/BO/modules/autoupgrade/index.ts
@@ -8,7 +8,7 @@ import type {Page} from '@playwright/test';
  * @extends ModuleConfiguration
  */
 class Autoupgrade extends ModuleConfiguration implements ModuleAutoupgradeMainPageInterface {
-  public readonly pageTitle: string;
+  public pageTitle: string;
 
   public readonly checkRequirementSuccessMessage: string;
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Fix autoupgrade page title for PS 1.7.1
| Type?             | refactor
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | no
| Sponsor company   | @PrestaSHopCore
| How to test?      | Ci is :green_apple: 
