### PR TITLE
`boCartRulesPage` & `boCatalogPriceRulesPage` : Added method for (un/)selecting all rows & get selected rows

### DIFF
--- a/src/interfaces/BO/catalog/discounts/catalogPriceRules/index.ts
+++ b/src/interfaces/BO/catalog/discounts/catalogPriceRules/index.ts
@@ -5,11 +5,13 @@ export interface BOCatalogPriceRulesPageInterface extends BOBasePagePageInterfac
   readonly pageTitle: string;
 
   bulkDeletePriceRules(page: Page): Promise<string>;
+  bulkSelectRows(page: Page, status?: boolean): Promise<void>;
   deleteCatalogPriceRule(page: Page, ruleName: string): Promise<string>;
   filterByDate(page: Page, filterBy: string, dateFrom: string, dateTo: string): Promise<void>;
   filterPriceRules(page: Page, filterType: string, filterBy: string, value: string): Promise<void>;
   getAllRowsColumnContent(page: Page, columnName: string): Promise<string[]>;
   getNumberOfElementInGrid(page: Page): Promise<number>;
+  getSelectedRowsCount(page: Page): Promise<number>;
   getTextColumn(page: Page, row: number, columnName: string): Promise<string>;
   goToAddNewCatalogPriceRulePage(page: Page): Promise<void>;
   goToEditCatalogPriceRulePage(page: Page, ruleName: string): Promise<void>;

--- a/src/interfaces/BO/catalog/discounts/index.ts
+++ b/src/interfaces/BO/catalog/discounts/index.ts
@@ -5,12 +5,14 @@ export interface BOCartRulesPageInterface extends BOBasePagePageInterface {
   readonly pageTitle: string;
 
   bulkDeleteCartRules(page: Page): Promise<string>;
+  bulkSelectRows(page: Page, status?: boolean): Promise<void>;
   bulkSetStatus(page: Page, wantedStatus: boolean): Promise<void>;
   deleteCartRule(page: Page, row?: number, cartRuleName?: string): Promise<string>;
   filterCartRules(page: Page, filterType: string, filterBy: string, value: string): Promise<void>;
   getAllRowsColumnContent(page: Page, columnName: string): Promise<string[]>;
   getCartRuleStatus(page: Page, row: number): Promise<boolean>;
   getNumberOfElementInGrid(page: Page): Promise<number>;
+  getSelectedRowsCount(page: Page): Promise<number>;
   getTextColumn(page: Page, row: number, columnName: string): Promise<string>;
   goToAddNewCartRulesPage(page: Page): Promise<void>;
   goToCatalogPriceRulesTab(page: Page): Promise<void>;

--- a/src/versions/develop/pages/BO/catalog/discounts/catalogPriceRules/index.ts
+++ b/src/versions/develop/pages/BO/catalog/discounts/catalogPriceRules/index.ts
@@ -36,11 +36,13 @@ class BOCatalogPriceRulesPage extends BOBasePage implements BOCatalogPriceRulesP
 
   private readonly tableBody: string;
 
-  private readonly tableRow: (row: number) => string;
+  private readonly tableRow: (row?: number) => string;
 
   private readonly tableEmptyRow: string;
 
-  private readonly tableColumn: (row: number, column: number) => string;
+  private readonly tableColumn: (row?: number, column?: number) => string;
+
+  private readonly tableColumnSelectRowCheckbox: (row?: number) => string;
 
   private readonly actionsColumn: (row: number) => string;
 
@@ -61,6 +63,8 @@ class BOCatalogPriceRulesPage extends BOBasePage implements BOCatalogPriceRulesP
   private readonly bulkActionDropdownMenu: string;
 
   private readonly selectAllLink: string;
+
+  private readonly unselectAllLink: string;
 
   private readonly bulkDeleteLink: string;
 
@@ -113,9 +117,12 @@ class BOCatalogPriceRulesPage extends BOBasePage implements BOCatalogPriceRulesP
 
     // Table rows and columns
     this.tableBody = `${this.gridTable} tbody`;
-    this.tableRow = (row: number) => `${this.tableBody} tr:nth-child(${row})`;
+    this.tableRow = (row?: number) => `${this.tableBody} tr${row === undefined ? '' : `:nth-child(${row})`}`;
     this.tableEmptyRow = `${this.tableBody} tr.empty_row`;
-    this.tableColumn = (row: number, column: number) => `${this.tableRow(row)} td:nth-child(${column})`;
+    this.tableColumn = (row?: number, column?: number) => `${this.tableRow(row)} td`
+      + `${column === undefined ? '' : `:nth-child(${column})`}`;
+    this.tableColumnSelectRowCheckbox = (row?: number) => `${this.tableColumn(undefined, row)
+    } input[name='specific_price_ruleBox[]']`;
 
     // Actions buttons in Row
     this.actionsColumn = (row: number) => `${this.tableRow(row)} td .btn-group-action`;
@@ -130,6 +137,7 @@ class BOCatalogPriceRulesPage extends BOBasePage implements BOCatalogPriceRulesP
     this.bulkActionMenuButton = '#bulk_action_menu_specific_price_rule';
     this.bulkActionDropdownMenu = `${this.bulkActionBlock} ul.dropdown-menu`;
     this.selectAllLink = `${this.bulkActionDropdownMenu} li:nth-child(1)`;
+    this.unselectAllLink = `${this.bulkActionDropdownMenu} li:nth-child(2)`;
     this.bulkDeleteLink = `${this.bulkActionDropdownMenu} li:nth-child(4)`;
 
     // Sort Selectors
@@ -327,16 +335,25 @@ class BOCatalogPriceRulesPage extends BOBasePage implements BOCatalogPriceRulesP
 
   /**
    * Select all rows
-   * @param page
+   * @param page {Page} Browser tab
    * @return {Promise<void>}
    */
-  async bulkSelectRows(page: Page): Promise<void> {
+  async bulkSelectRows(page: Page, status: boolean = true): Promise<void> {
     await page.locator(this.bulkActionMenuButton).click();
 
     await Promise.all([
-      page.locator(this.selectAllLink).click(),
-      this.waitForHiddenSelector(page, this.selectAllLink),
+      page.locator(status ? this.selectAllLink : this.unselectAllLink).click(),
+      this.waitForHiddenSelector(page, status ? this.selectAllLink : this.unselectAllLink),
     ]);
+  }
+
+  /**
+   * Returns number of selected rows
+   * @param page {Page} Browser tab
+   * @return {Promise<number>}
+   */
+  async getSelectedRowsCount(page: Page): Promise<number> {
+    return page.locator(`${this.tableColumnSelectRowCheckbox(undefined)}:checked`).count();
   }
 
   /**

--- a/src/versions/develop/pages/BO/catalog/discounts/index.ts
+++ b/src/versions/develop/pages/BO/catalog/discounts/index.ts
@@ -76,6 +76,8 @@ class BOCartRulesPage extends BOBasePage implements BOCartRulesPageInterface {
 
   private readonly selectAllLink: string;
 
+  private readonly unselectAllLink: string;
+
   private readonly bulkEnableLink: string;
 
   private readonly bulkDisableLink: string;
@@ -159,6 +161,7 @@ class BOCartRulesPage extends BOBasePage implements BOCartRulesPageInterface {
     this.bulkActionMenuButton = '#bulk_action_menu_cart_rule';
     this.bulkActionDropdownMenu = `${this.bulkActionBlock} ul.dropdown-menu`;
     this.selectAllLink = `${this.bulkActionDropdownMenu} li:nth-child(1)`;
+    this.unselectAllLink = `${this.bulkActionDropdownMenu} li:nth-child(2)`;
     this.bulkEnableLink = `${this.bulkActionDropdownMenu} li:nth-child(4)`;
     this.bulkDisableLink = `${this.bulkActionDropdownMenu} li:nth-child(5)`;
     this.bulkDeleteLink = `${this.bulkActionDropdownMenu} li:nth-child(7)`;
@@ -386,13 +389,22 @@ class BOCartRulesPage extends BOBasePage implements BOCartRulesPageInterface {
    * @param page {Page} Browser tab
    * @return {Promise<void>}
    */
-  async bulkSelectRows(page: Page): Promise<void> {
+  async bulkSelectRows(page: Page, status: boolean = true): Promise<void> {
     await page.locator(this.bulkActionMenuButton).click();
 
     await Promise.all([
-      page.locator(this.selectAllLink).click(),
-      this.waitForHiddenSelector(page, this.selectAllLink),
+      page.locator(status ? this.selectAllLink : this.unselectAllLink).click(),
+      this.waitForHiddenSelector(page, status ? this.selectAllLink : this.unselectAllLink),
     ]);
+  }
+
+  /**
+   * Returns number of selected rows
+   * @param page {Page} Browser tab
+   * @return {Promise<number>}
+   */
+  async getSelectedRowsCount(page: Page): Promise<number> {
+    return page.locator(`${this.tableColumnSelectRowCheckbox}:checked`).count();
   }
 
   /**


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | `boCartRulesPage` & `` : Added method for (un/)selecting all rows & get selected rows
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is :green_circle: 
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp