### PR TITLE
`boOrdersViewBasePage` : Fixes `modifyOrderStatus` method for <8.2 versions

### DIFF
--- a/src/pages/BO/orders/view/viewOrderBasePage.ts
+++ b/src/pages/BO/orders/view/viewOrderBasePage.ts
@@ -11,6 +11,9 @@ function requirePage(): BOViewOrderBasePageInterface {
   if (semver.lt(psVersion, '7.7.0')) {
     return require('@versions/1.7.6/pages/BO/orders/view/viewOrderBasePage').viewOrderBasePage;
   }
+  if (semver.lt(psVersion, '9.0.0')) {
+    return require('@versions/8.2/pages/BO/orders/view/viewOrderBasePage').viewOrderBasePage;
+  }
   return require('@versions/develop/pages/BO/orders/view/viewOrderBasePage').viewOrderBasePage;
 }
 

--- a/src/versions/1.7.6/pages/BO/orders/view/viewOrderBasePage.ts
+++ b/src/versions/1.7.6/pages/BO/orders/view/viewOrderBasePage.ts
@@ -1,6 +1,6 @@
 // Import pages
 import type {BOViewOrderBasePageInterface} from '@interfaces/BO/orders/view/viewOrderBasePage';
-import {ViewOrderBasePage} from '@versions/develop/pages/BO/orders/view/viewOrderBasePage';
+import {ViewOrderBasePage} from '@versions/8.2/pages/BO/orders/view/viewOrderBasePage';
 import type {Page} from 'playwright-core';
 
 /**

--- a/src/versions/8.2/pages/BO/orders/view/viewOrderBasePage.ts
+++ b/src/versions/8.2/pages/BO/orders/view/viewOrderBasePage.ts
@@ -1,0 +1,33 @@
+// Import pages
+import type {BOViewOrderBasePageInterface} from '@interfaces/BO/orders/view/viewOrderBasePage';
+import {ViewOrderBasePage} from '@versions/develop/pages/BO/orders/view/viewOrderBasePage';
+import type {Page} from 'playwright-core';
+
+/**
+ * View orders page, contains functions that can be used in the page
+ * @class
+ * @extends OrdersPage
+ */
+class ViewOrderBasePageVersion extends ViewOrderBasePage implements BOViewOrderBasePageInterface {
+  /**
+   * Modify the order status
+   * @param page {Page} Browser tab
+   * @param status {string} Status to edit
+   * @returns {Promise<string>}
+   */
+  async modifyOrderStatus(page: Page, status: string): Promise<string> {
+    const actualStatus = await this.getOrderStatus(page);
+
+    if (status !== actualStatus) {
+      await this.selectByVisibleText(page, this.orderStatusesSelect, status);
+      await page.locator(this.updateStatusButton).click();
+      await page.waitForLoadState();
+      return this.getOrderStatus(page);
+    }
+
+    return actualStatus;
+  }
+}
+
+const viewOrderBasePage = new ViewOrderBasePageVersion();
+export {viewOrderBasePage, ViewOrderBasePageVersion as ViewOrderBasePage};

--- a/src/versions/develop/pages/BO/orders/view/viewOrderBasePage.ts
+++ b/src/versions/develop/pages/BO/orders/view/viewOrderBasePage.ts
@@ -46,11 +46,11 @@ class ViewOrderBasePage extends BOBasePage implements BOViewOrderBasePageInterfa
 
   private readonly orderReference: string;
 
-  private readonly orderStatusesSelect: string;
+  protected readonly orderStatusesSelect: string;
 
   private readonly orderStatusesOptionSelect: string;
 
-  private readonly updateStatusButton: string;
+  protected readonly updateStatusButton: string;
 
   private readonly viewInvoiceButton: string;
 


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | develop
| Description?      | `boOrdersViewBasePage` : Fixes `modifyOrderStatus` method for <8.2 versions
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is :green_circle: 
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp