### PR TITLE
Stabilize module alert boc

### DIFF
--- a/src/versions/develop/pages/BO/modules/ps_facetedsearch/index.ts
+++ b/src/versions/develop/pages/BO/modules/ps_facetedsearch/index.ts
@@ -64,7 +64,7 @@ class PsFacetedSearch extends ModuleConfigurationPage implements ModulePsFaceted
     super();
 
     // Override
-    this.alertTextBlock = 'div.alert';
+    this.alertTextBlock = '#content > div.alert';
 
     this.pageSubTitle = 'Faceted search';
     this.msgSuccessfulCreation = (name: string) => `Your filter "${name}" was added successfully.`;
@@ -167,7 +167,7 @@ class PsFacetedSearch extends ModuleConfigurationPage implements ModulePsFaceted
    */
   async setShowProductsOnlyFromDefaultCategoryValue(page: Page, value: boolean): Promise<string> {
     await this.setChecked(page, this.showProductsOnlyFromDefaultCategoryCheckbox(value ? 'on' : 'off'), true);
-    await page.locator(this.btnConfigurationSave).click();
+    await this.clickAndWaitForLoadState(page, this.btnConfigurationSave);
 
     return this.getAlertBlockContent(page);
   }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Use clickAndWait instead of simple click, make alert selector stricter to avoid catching another alert message added by an external module
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | ~
| Sponsor company   | ~
| How to test?      | ~
