### PR TITLE
Add generateRobotsTextFile method to BOSeoUrlsPage

### DIFF
--- a/src/interfaces/BO/shopParameters/trafficAndSeo/seoAndUrls/index.ts
+++ b/src/interfaces/BO/shopParameters/trafficAndSeo/seoAndUrls/index.ts
@@ -20,6 +20,7 @@ export interface BOSeoUrlsPageInterface extends BOBasePagePageInterface {
   paginationPrevious(page: Page): Promise<string>;
   resetAndGetNumberOfLines(page: Page): Promise<number>;
   selectPaginationLimit(page: Page, number: number): Promise<string>;
+  generateRobotsTextFile(page: Page): Promise<string>;
   setStatusAttributesInProductMetaTitle(page: Page, toEnable?: boolean): Promise<string>;
   sortTable(page: Page, sortBy: string, sortDirection: string): Promise<void>;
 }

--- a/src/interfaces/BO/shopParameters/trafficAndSeo/seoAndUrls/index.ts
+++ b/src/interfaces/BO/shopParameters/trafficAndSeo/seoAndUrls/index.ts
@@ -10,6 +10,7 @@ export interface BOSeoUrlsPageInterface extends BOBasePagePageInterface {
   enableDisableAccentedURL(page: Page, toEnable?: boolean): Promise<string>;
   enableDisableFriendlyURL(page: Page, toEnable?: boolean): Promise<string>;
   filterTable(page: Page, filterBy: string, value?: string): Promise<void>;
+  generateRobotsTextFile(page: Page): Promise<string>;
   getAllRowsColumnContent(page: Page, column: string): Promise<string[]>;
   getNumberOfElementInGrid(page: Page): Promise<number>;
   getTextColumnFromTable(page: Page, row: number, column: string): Promise<string>;
@@ -20,7 +21,6 @@ export interface BOSeoUrlsPageInterface extends BOBasePagePageInterface {
   paginationPrevious(page: Page): Promise<string>;
   resetAndGetNumberOfLines(page: Page): Promise<number>;
   selectPaginationLimit(page: Page, number: number): Promise<string>;
-  generateRobotsTextFile(page: Page): Promise<string>;
   setStatusAttributesInProductMetaTitle(page: Page, toEnable?: boolean): Promise<string>;
   sortTable(page: Page, sortBy: string, sortDirection: string): Promise<void>;
 }

--- a/src/versions/develop/pages/BO/shopParameters/trafficAndSeo/seoAndUrls/index.ts
+++ b/src/versions/develop/pages/BO/shopParameters/trafficAndSeo/seoAndUrls/index.ts
@@ -80,6 +80,8 @@ class BOSeoUrlsPage extends BOBasePage implements BOSeoUrlsPageInterface {
 
   private readonly saveSeoOptionsFormButton: string;
 
+  private readonly generateRobotsFileButton: string;
+
   /**
    * @constructs
    * Setting up titles and selectors to use on seo and urls page
@@ -148,6 +150,9 @@ class BOSeoUrlsPage extends BOBasePage implements BOSeoUrlsPageInterface {
     this.displayAttributesToggleInput = (toggle: number) => '#meta_settings_seo_options_form_product_attributes_in_title_'
       + `${toggle}`;
     this.saveSeoOptionsFormButton = '#meta_settings_seo_options_form_save_button';
+
+    // Robots file generation form
+    this.generateRobotsFileButton = 'form[action*="generate/robots"] button.btn-primary';
   }
 
   /* header methods */
@@ -409,6 +414,17 @@ class BOSeoUrlsPage extends BOBasePage implements BOSeoUrlsPageInterface {
     await this.setChecked(page, this.accentedUrlToggleInput(toEnable ? 1 : 0));
     await this.clickAndWaitForLoadState(page, this.saveSeoAndUrlFormButton);
     await this.elementNotVisible(page, this.accentedUrlToggleInput(!toEnable ? 1 : 0), 2000);
+
+    return this.getAlertSuccessBlockParagraphContent(page);
+  }
+
+  /**
+   * Generate robots.txt file
+   * @param page {Page} Browser tab
+   * @return {Promise<string>}
+   */
+  async generateRobotsTextFile(page: Page): Promise<string> {
+    await this.clickAndWaitForURL(page, this.generateRobotsFileButton);
 
     return this.getAlertSuccessBlockParagraphContent(page);
   }


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions                   | Answers
| --------------------------- | -------------------------------------------------------
| Branch?                     | main
| Description?                | Add `generateRobotsTextFile` method to `BOSeoUrlsPage` to support automated testing of the robots.txt file generation feature (BO > Shop Parameters > SEO & URLs)
| Type?                       | improvement
| Category?                   | TE
| BC breaks?                  | no
| Deprecations?               | no
| How to test?                | CI is :green_circle:
| Fixed issue or discussion?  | N/A
| Related PRs                 | https://github.com/PrestaShop/PrestaShop/pull/41311 (test PR that depends on this one)
| Sponsor company             | @PrestaShopCorp