### PR TITLE
Fix BOBasePage help sidebar methods to support legacy pages

### DIFF
--- a/src/pages/BO/BOBasePage.ts
+++ b/src/pages/BO/BOBasePage.ts
@@ -275,6 +275,12 @@ export default class BOBasePage extends CommonPage implements BOBasePagePageInte
 
   private readonly helpDocumentURL: string;
 
+  private readonly legacyHelpButton: string;
+
+  private readonly legacyHelpContainer: string;
+
+  private readonly legacyMainContainer: string;
+
   private readonly invalidTokenContinueLink: string;
 
   private readonly invalidTokenCancelLink: string;
@@ -338,6 +344,7 @@ export default class BOBasePage extends CommonPage implements BOBasePagePageInte
 
     // Header links
     this.helpButton = '#product_form_open_help';
+    this.legacyHelpButton = '.toolbarBox a.btn-help';
     this.menuMobileButton = '.js-mobile-menu';
     this.notificationsLink = '#notification,#notif';
     this.notificationsDropDownMenu = '#notification div.dropdown-menu-right.notifs_dropdown,#notif div.dropdown-menu';
@@ -642,10 +649,14 @@ export default class BOBasePage extends CommonPage implements BOBasePagePageInte
     this.sfToolbarMainContentDiv = "div[id*='sfToolbarMainContent']";
     this.sfCloseToolbarLink = "[id*='sfToolbarHideButton'], a.hide-button";
 
-    // Sidebar
+    // Sidebar (Symfony)
     this.rightSidebar = '#right-sidebar';
     this.rightCloseButton = `${this.rightSidebar} #ps-quicknav-sidebar .quicknav-header [data-target=".sidebar"]`;
     this.helpDocumentURL = `${this.rightSidebar} div.quicknav-scroller._fullspace object`;
+
+    // Sidebar (Legacy)
+    this.legacyHelpContainer = '#help-container';
+    this.legacyMainContainer = '#main';
 
     // Invalid token block
     this.invalidTokenContinueLink = '#security-compromised-page #csrf-white-container div a:nth-child(1)';
@@ -1126,8 +1137,14 @@ export default class BOBasePage extends CommonPage implements BOBasePagePageInte
    * @returns {Promise<boolean>}
    */
   async openHelpSideBar(page: Page): Promise<boolean> {
-    await this.waitForSelectorAndClick(page, this.helpButton);
-    return this.elementVisible(page, `${this.rightSidebar}.sidebar-open`, 2000);
+    // Symfony sidebar: button with #product_form_open_help
+    if (await this.elementVisible(page, this.helpButton, 1000)) {
+      await this.waitForSelectorAndClick(page, this.helpButton);
+      return this.elementVisible(page, `${this.rightSidebar}.sidebar-open`, 2000);
+    }
+    // Legacy sidebar: button with .toolbarBox a.btn-help
+    await this.waitForSelectorAndClick(page, this.legacyHelpButton);
+    return this.elementVisible(page, `${this.legacyMainContainer}.helpOpen`, 2000);
   }
 
   /**
@@ -1136,8 +1153,14 @@ export default class BOBasePage extends CommonPage implements BOBasePagePageInte
    * @returns {Promise<boolean>}
    */
   async closeHelpSideBar(page: Page): Promise<boolean> {
-    await this.waitForSelectorAndClick(page, this.rightCloseButton);
-    return this.elementVisible(page, `${this.rightSidebar}:not(.sidebar-open)`, 2000);
+    // Symfony sidebar
+    if (await this.elementVisible(page, this.rightCloseButton, 1000)) {
+      await this.waitForSelectorAndClick(page, this.rightCloseButton);
+      return this.elementVisible(page, `${this.rightSidebar}:not(.sidebar-open)`, 2000);
+    }
+    // Legacy sidebar: click the button again to toggle it off
+    await this.waitForSelectorAndClick(page, this.legacyHelpButton);
+    return this.elementNotVisible(page, `${this.legacyMainContainer}.helpOpen`, 2000);
   }
 
   /**
@@ -1146,7 +1169,12 @@ export default class BOBasePage extends CommonPage implements BOBasePagePageInte
    * @returns {Promise<string>}
    */
   async getHelpDocumentURL(page: Page): Promise<string> {
-    return this.getAttributeContent(page, this.helpDocumentURL, 'data');
+    // Symfony sidebar: URL is in the <object data="..."> inside the sidebar
+    if (await this.elementVisible(page, this.helpDocumentURL, 1000)) {
+      return this.getAttributeContent(page, this.helpDocumentURL, 'data');
+    }
+    // Legacy sidebar: URL is in the href attribute of the help button (contains country=en)
+    return this.getAttributeContent(page, this.legacyHelpButton, 'href');
   }
 
   /**


### PR DESCRIPTION
| Questions | Answers
| --------- | -------
| Branch? | main
| Description? | `openHelpSideBar()`, `closeHelpSideBar()` and `getHelpDocumentURL()` in `BOBasePage` only worked with the Symfony sidebar mechanism (`#product_form_open_help` / `#right-sidebar`). Legacy pages use a completely different mechanism: the help button is `.toolbarBox a.btn-help`, the sidebar indicator is `#main.helpOpen`, and content is loaded via AJAX into `#help-container`.<br><br>Each method now detects which mechanism is available and falls back to the legacy one when the Symfony sidebar is not present:<br>- `openHelpSideBar`: clicks `.toolbarBox a.btn-help`, checks `#main.helpOpen`<br>- `closeHelpSideBar`: re-clicks the button to toggle the sidebar off, checks `#main` no longer has `helpOpen`<br>- `getHelpDocumentURL`: returns the `href` attribute of the help button (which contains `country=en`)
| Type? | improvement
| BC breaks? | no
| Related PR | PrestaShop/PrestaShop#41540