### PR TITLE
Fix: Correct free gift selectors for develop version

### DIFF
--- a/src/versions/develop/pages/BO/catalog/discountsV2/create.ts
+++ b/src/versions/develop/pages/BO/catalog/discountsV2/create.ts
@@ -172,11 +172,11 @@ class BODiscountsCreatePage extends BOBasePage implements BODiscountsCreatePageI
     this.deliveryConditionSpecificCountriesInput = 'div.toggle-children-choice-child[data-toggle-name="country"] input'
       + '.select2-search__field';
     // Free gift
-    this.freeGiftSearchInput = '#discount_free_gift_product_search_input';
+    this.freeGiftSearchInput = '#discount_free_gift_search_input';
     this.searchProductResult = '.tt-menu.tt-open';
-    this.freeGiftList = '#discount_free_gift_product_list';
+    this.freeGiftList = '#discount_free_gift_list';
     this.freeGiftErrorMessage = 'div.form-group .alert-danger';
-    this.discountFreeGiftRow = (row: number) => `#discount_free_gift_product_${row}`;
+    this.discountFreeGiftRow = (row: number) => `#discount_free_gift_${row}`;
     this.freeGiftDeleteIcon = (row: number) => `${this.discountFreeGiftRow(row)} div.media-body.media-middle i`;
     this.modalConfirmRemove = '#modal-confirm-remove-entity';
     this.modalConfirmRemoveSubmitButton = `${this.modalConfirmRemove} button.btn-confirm-submit`;


### PR DESCRIPTION
## Problem

The selectors for the free gift product search in the `develop` version page object were wrong since PR #972.

The `_product_` segment was added to the IDs but it does not exist in the rendered HTML. The Symfony form field is named `free_gift` directly under the root `discount` form:

```php
// DiscountType.php
->add('free_gift', ProductSearchType::class, [...])
```

Which generates these IDs:
- Container: `#discount_free_gift`
- Search input: `#discount_free_gift_search_input`
- List: `#discount_free_gift_list`

## Root cause

The `_product_` suffix was a confusion with the `specific_products` pattern which IS genuinely nested under `discount_conditions_product_` (a different sub-form). The `free_gift` field has no such nesting.

The bug was masked until commit `96815717be6` in PrestaShop fixed the test data from `discountType: 'Free gift'` to `discountType: 'free_gift'` — this activated the code path that calls `setValue()` on the broken selector.

## Fix

Revert the 3 selectors introduced in PR #972 to their correct values (matching the `9.1` version).

## After merge

`tests/UI/package.json` in the PrestaShop repository already points to `#main`:
```json
"@prestashop-core/ui-testing": "https://github.com/PrestaShop/ui-testing-library#main"
```

There is no version bump to do. Once this PR is merged, a **`npm install`** run in `tests/UI/` is enough to regenerate `package-lock.json` with the new commit SHA, and a dedicated PR must be opened in the PrestaShop repository to commit the updated `package-lock.json`.