### PR TITLE
Add getGroupRestrictionNames to BO payment preferences page object

### DIFF
--- a/src/interfaces/BO/payment/preferences.ts
+++ b/src/interfaces/BO/payment/preferences.ts
@@ -4,6 +4,7 @@ import {type Page} from '@playwright/test';
 export interface BOPaymentPreferencesPageInterface extends BOBasePagePageInterface {
   readonly pageTitle: string;
 
+  getGroupRestrictionNames(page: Page): Promise<string[]>;
   setCarrierRestriction(page: Page, carrierID: number, paymentModule: string, valueWanted: boolean): Promise<string>;
   setCountryRestriction(page: Page, countryID: number, paymentModule: string, valueWanted: boolean): Promise<string>;
   setCurrencyRestriction(page: Page, paymentModule: string, valueWanted: boolean): Promise<string>;

--- a/src/versions/develop/pages/BO/payment/preferences.ts
+++ b/src/versions/develop/pages/BO/payment/preferences.ts
@@ -47,7 +47,7 @@ class BOPaymentPreferencesPage extends BOBasePage implements BOPaymentPreference
       + `${paymentModule}_"][value="${countryID}"]`;
     this.groupRestrictionsSaveButton = '#form-group-restrictions-save-button';
     // One row per customer group in the group restrictions table, the group name being the first cell.
-    this.groupRestrictionsTableRows = 'div.card:has(#form-group-restrictions-save-button) table tbody tr';
+    this.groupRestrictionsTableRows = `div.card:has(${this.groupRestrictionsSaveButton}) table tbody tr`;
     this.groupRestrictionsTableRow = (row: number) => `${this.groupRestrictionsTableRows}:nth-child(${row})`;
     // Selectors fot carrier restriction
     this.carrierRestrictionsCheckbox = (paymentModule: string, carrierID: number) => '#form_carrier_restrictions_'

--- a/src/versions/develop/pages/BO/payment/preferences.ts
+++ b/src/versions/develop/pages/BO/payment/preferences.ts
@@ -20,6 +20,10 @@ class BOPaymentPreferencesPage extends BOBasePage implements BOPaymentPreference
 
   private readonly groupRestrictionsSaveButton: string;
 
+  private readonly groupRestrictionsTableRow: (row: number) => string;
+
+  private readonly groupRestrictionsTableRows: string;
+
   private readonly carrierRestrictionsCheckbox: (paymentModule: string, carrierID: number) => string;
 
   private readonly carrierRestrictionSaveButton: string;
@@ -42,6 +46,9 @@ class BOPaymentPreferencesPage extends BOBasePage implements BOPaymentPreference
     this.countryRestrictionsCheckbox = (paymentModule: string, countryID: number) => 'input[id^="form_country_restrictions_'
       + `${paymentModule}_"][value="${countryID}"]`;
     this.groupRestrictionsSaveButton = '#form-group-restrictions-save-button';
+    // One row per customer group in the group restrictions table, the group name being the first cell.
+    this.groupRestrictionsTableRows = 'div.card:has(#form-group-restrictions-save-button) table tbody tr';
+    this.groupRestrictionsTableRow = (row: number) => `${this.groupRestrictionsTableRows}:nth-child(${row})`;
     // Selectors fot carrier restriction
     this.carrierRestrictionsCheckbox = (paymentModule: string, carrierID: number) => '#form_carrier_restrictions_'
       + `${paymentModule}_${carrierID}`;
@@ -122,6 +129,25 @@ class BOPaymentPreferencesPage extends BOBasePage implements BOPaymentPreference
 
     await page.locator(this.carrierRestrictionSaveButton).click();
     return this.getAlertSuccessBlockParagraphContent(page);
+  }
+
+  /**
+   * Get the names of the customer groups listed in the group restrictions table.
+   * In a multishop context, only the groups of the currently selected shop should be listed.
+   * @param page {Page} Browser tab
+   * @returns {Promise<string[]>}
+   */
+  async getGroupRestrictionNames(page: Page): Promise<string[]> {
+    await this.waitForVisibleSelector(page, this.groupRestrictionsSaveButton);
+
+    const rowsNumber = await page.locator(this.groupRestrictionsTableRows).count();
+    const groupNames: string[] = [];
+
+    for (let row = 1; row <= rowsNumber; row++) {
+      groupNames.push(await this.getTextContent(page, `${this.groupRestrictionsTableRow(row)} td:first-child`));
+    }
+
+    return groupNames;
   }
 }
 


### PR DESCRIPTION
## Description

Adds a `getGroupRestrictionNames(page)` method to the BO **Payment > Preferences** page object (`boPaymentPreferencesPage`), returning the names of the customer groups listed in the "Group restrictions" table.

This is needed to assert, in a multishop context, that the group restrictions table only lists the customer groups of the currently selected shop.

## Related

- Used by the new functional test added in PrestaShop/PrestaShop for issue https://github.com/PrestaShop/PrestaShop/issues/9858 (filtering of payment group restrictions per shop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)