### PR TITLE
Update Hummingbird v2.1.0 UI Test

### DIFF
--- a/src/pages/FO/hummingbird/modal/quickView.ts
+++ b/src/pages/FO/hummingbird/modal/quickView.ts
@@ -9,6 +9,9 @@ function requirePage(): FoModalQuickViewPageInterface {
   if (semver.lt(psVersion, '9.1.0')) {
     return require('@versions/9.0/pages/FO/hummingbird/modal/quickView').foModalQuickViewPage;
   }
+  if (semver.lt(psVersion, '9.2.0')) {
+    return require('@versions/9.1/pages/FO/hummingbird/modal/quickView').foModalQuickViewPage;
+  }
   return require('@versions/develop/pages/FO/hummingbird/modal/quickView').foModalQuickViewPage;
 }
 /* eslint-enable global-require, @typescript-eslint/no-require-imports */

--- a/src/pages/FO/hummingbird/myAccount/index.ts
+++ b/src/pages/FO/hummingbird/myAccount/index.ts
@@ -9,6 +9,9 @@ function requirePage(): FoMyAccountPageInterface {
   if (semver.lt(psVersion, '9.1.0')) {
     return require('@versions/9.0/pages/FO/hummingbird/myAccount').foMyAccountPage;
   }
+  if (semver.lt(psVersion, '9.2.0')) {
+    return require('@versions/9.1/pages/FO/hummingbird/myAccount').foMyAccountPage;
+  }
   return require('@versions/develop/pages/FO/hummingbird/myAccount').myAccountPage;
 }
 /* eslint-enable global-require, @typescript-eslint/no-require-imports */

--- a/src/pages/FO/hummingbird/product/index.ts
+++ b/src/pages/FO/hummingbird/product/index.ts
@@ -9,6 +9,9 @@ function requirePage(): FoProductHummingbirdPageInterface {
   if (semver.lt(psVersion, '9.1.0')) {
     return require('@versions/9.0/pages/FO/hummingbird/product').foProductPage;
   }
+  if (semver.lt(psVersion, '9.2.0')) {
+    return require('@versions/9.1/pages/FO/hummingbird/product').foProductPage;
+  }
   return require('@versions/develop/pages/FO/hummingbird/product').foProductPage;
 }
 /* eslint-enable global-require, @typescript-eslint/no-require-imports */

--- a/src/versions/9.1/pages/FO/hummingbird/modal/quickView.ts
+++ b/src/versions/9.1/pages/FO/hummingbird/modal/quickView.ts
@@ -1,0 +1,26 @@
+import {type FoModalQuickViewPageInterface} from '@interfaces/FO/modal/quickView';
+import {FoModalQuickViewPage as FoModalQuickViewPageVersion} from '@versions/develop/pages/FO/hummingbird/modal/quickView';
+
+/**
+ * Quick view modal, contains functions that can be used on the page
+ * @class
+ * @extends FoModalQuickViewPageVersion
+ */
+class FoModalQuickViewPage extends FoModalQuickViewPageVersion implements FoModalQuickViewPageInterface {
+  /**
+   * @constructs
+   * Setting up texts and selectors to use on quick view modal
+   */
+  constructor() {
+    super();
+
+    // Quick view modal
+    // Before Hummingbird wrapped each thumbnail button in `li.product__thumbnails-item`,
+    // the button was a direct child of `ul.product__thumbnails-list`.
+    this.quickViewThumbImagePosition = (position: number) => `${this.quickViewModalDiv} ul.product__thumbnails-list `
+      + `button:nth-child(${position}) img`;
+  }
+}
+
+const foModalQuickViewPage = new FoModalQuickViewPage();
+export {foModalQuickViewPage, FoModalQuickViewPage};

--- a/src/versions/9.1/pages/FO/hummingbird/myAccount/index.ts
+++ b/src/versions/9.1/pages/FO/hummingbird/myAccount/index.ts
@@ -1,0 +1,24 @@
+import {FoMyAccountPageInterface} from '@interfaces/FO/myAccount';
+import {MyAccountPage as MyAccountPageVersion} from '@versions/develop/pages/FO/hummingbird/myAccount';
+
+/**
+ * My account page, contains functions that can be used on the page
+ * @class
+ * @extends MyAccountPageVersion
+ */
+class FoMyAccountPage extends MyAccountPageVersion implements FoMyAccountPageInterface {
+  /**
+   * @constructs
+   * Setting up texts and selectors to use on my account page
+   */
+  constructor() {
+    super();
+
+    // Selectors
+    this.myWishlistsLink = '.account-menu__nav #wishlist_link';
+    this.psgdprLink = '.account-menu__nav #psgdpr_link';
+  }
+}
+
+const foMyAccountPage = new FoMyAccountPage();
+export {foMyAccountPage, FoMyAccountPage};

--- a/src/versions/9.1/pages/FO/hummingbird/product/index.ts
+++ b/src/versions/9.1/pages/FO/hummingbird/product/index.ts
@@ -1,0 +1,25 @@
+import {type FoProductHummingbirdPageInterface} from '@interfaces/FO/product';
+import {FoProductPage as FoProductPageVersion} from '@versions/develop/pages/FO/hummingbird/product';
+
+/**
+ * Product page, contains functions that can be used on the page
+ * @class
+ * @extends FoProductPageVersion
+ */
+class FoProductPage extends FoProductPageVersion implements FoProductHummingbirdPageInterface {
+  /**
+   * @constructs
+   * Setting up texts and selectors to use on product page
+   */
+  constructor() {
+    super();
+
+    // Before Hummingbird wrapped each thumbnail button in `li.product__thumbnails-item`,
+    // the button (`.product__thumbnail`) was a direct child of `ul.product__thumbnails-list`.
+    this.productImageRow = (row: number) => `.product__images .product__thumbnails-list `
+      + `.product__thumbnail:nth-child(${row})`;
+  }
+}
+
+const foProductPage = new FoProductPage();
+export {foProductPage, FoProductPage};

--- a/src/versions/9.1/pages/FO/hummingbird/product/index.ts
+++ b/src/versions/9.1/pages/FO/hummingbird/product/index.ts
@@ -16,7 +16,7 @@ class FoProductPage extends FoProductPageVersion implements FoProductHummingbird
 
     // Before Hummingbird wrapped each thumbnail button in `li.product__thumbnails-item`,
     // the button (`.product__thumbnail`) was a direct child of `ul.product__thumbnails-list`.
-    this.productImageRow = (row: number) => `.product__images .product__thumbnails-list `
+    this.productImageRow = (row: number) => '.product__images .product__thumbnails-list '
       + `.product__thumbnail:nth-child(${row})`;
   }
 }

--- a/src/versions/develop/pages/FO/hummingbird/modal/quickView.ts
+++ b/src/versions/develop/pages/FO/hummingbird/modal/quickView.ts
@@ -34,7 +34,7 @@ class FoModalQuickViewPage extends FoModalQuickViewPageClassic implements FoModa
     this.quickViewProductColor = `${this.quickViewProductVariants} div[id^="group_2"]`;
     this.quickViewCloseButton = `${this.quickViewModalDiv} .quickview__header button.btn-close`;
     this.quickViewThumbImagePosition = (position: number) => `${this.quickViewModalDiv} ul.product__thumbnails-list `
-      + `button:nth-child(${position}) img`;
+      + `li.product__thumbnails-item:nth-child(${position}) button img`;
   }
 
   /**

--- a/src/versions/develop/pages/FO/hummingbird/myAccount/index.ts
+++ b/src/versions/develop/pages/FO/hummingbird/myAccount/index.ts
@@ -24,8 +24,8 @@ class MyAccountPage extends MyAccountPageVersion implements FoMyAccountPageInter
     this.orderSlipsLink = '#order-slips_link';
     this.successMessageAlert = 'div.alert';
     this.logoutFooterLink = '#footer_customeraccountlinks a.logout';
-    this.myWishlistsLink = '.account-menu__nav #wishlist_link';
-    this.psgdprLink = '.account-menu__nav #psgdpr_link';
+    this.myWishlistsLink = '.account-menu__nav .account-menu__link--wishlist';
+    this.psgdprLink = '.account-menu__nav .account-menu__link--psgdpr';
   }
 }
 

--- a/src/versions/develop/pages/FO/hummingbird/product/index.ts
+++ b/src/versions/develop/pages/FO/hummingbird/product/index.ts
@@ -47,7 +47,7 @@ class FoProductPage extends FoProductPageClassic implements FoProductHummingbird
     this.productCoverImgProductModal = `${this.productCarouselImageItem}.active img`;
     this.carouselControlProductModal = (direction: string) => '#product-modal .product-images-modal__body'
       + ` button.carousel-control-${direction}`;
-    this.productImageRow = (row: number) => `.product__images .product__thumbnails-list `
+    this.productImageRow = (row: number) => '.product__images .product__thumbnails-list '
       + `.product__thumbnails-item:nth-child(${row}) .product__thumbnail`;
     this.thumbImg = (row: number) => `${this.productImageRow(row)} picture img.js-thumb`;
     this.zoomIcon = '.product__images .product__carousel .product__zoom';

--- a/src/versions/develop/pages/FO/hummingbird/product/index.ts
+++ b/src/versions/develop/pages/FO/hummingbird/product/index.ts
@@ -47,7 +47,8 @@ class FoProductPage extends FoProductPageClassic implements FoProductHummingbird
     this.productCoverImgProductModal = `${this.productCarouselImageItem}.active img`;
     this.carouselControlProductModal = (direction: string) => '#product-modal .product-images-modal__body'
       + ` button.carousel-control-${direction}`;
-    this.productImageRow = (row: number) => `.product__images .product__thumbnails-list .product__thumbnail:nth-child(${row})`;
+    this.productImageRow = (row: number) => `.product__images .product__thumbnails-list `
+      + `.product__thumbnails-item:nth-child(${row}) .product__thumbnail`;
     this.thumbImg = (row: number) => `${this.productImageRow(row)} picture img.js-thumb`;
     this.zoomIcon = '.product__images .product__carousel .product__zoom';
     this.productName = '#wrapper .product__name';


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/9/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Hummingbird PR [#1033](https://github.com/PrestaShop/hummingbird/pull/1033) removes id attributes (wishlist_link, psgdpr_link, emailalerts_link) from customer account module links to fix duplicate ID violations (the displayCustomerAccount hook renders in two places simultaneously). BEM modifier classes are added as replacements.
| Type?             | bug fix
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | --
| Sponsor company   | @PrestaShopCorp
| How to test?      | --
