### PR TITLE
Fix addCurrentPageToQuickAccess to interact with modal instead of window.prompt()

### DIFF
--- a/src/pages/BO/BOBasePage.ts
+++ b/src/pages/BO/BOBasePage.ts
@@ -59,6 +59,12 @@ export default class BOBasePage extends CommonPage implements BOBasePagePageInte
 
   private readonly manageYourQuickAccessLink: string;
 
+  private readonly quickAccessAddModal: string;
+
+  private readonly quickAccessAddModalNameInput: string;
+
+  private readonly quickAccessAddModalSaveButton: string;
+
   private readonly navbarSearchInput: string;
 
   protected readonly helpButton: string;
@@ -334,6 +340,9 @@ export default class BOBasePage extends CommonPage implements BOBasePagePageInte
     this.quickAddCurrentLink = `${this.quickAccessContainer} #quick-add-link`;
     this.quickAccessRemoveLink = `${this.quickAccessContainer} #quick-remove-link`;
     this.manageYourQuickAccessLink = `${this.quickAccessContainer} #quick-manage-link`;
+    this.quickAccessAddModal = '#quick-access-add-modal';
+    this.quickAccessAddModalNameInput = `${this.quickAccessAddModal} #quick-access-name`;
+    this.quickAccessAddModalSaveButton = `${this.quickAccessAddModal} #quick-access-save-btn`;
     this.navbarSearchInput = '#bo_query';
 
     // Header links
@@ -735,9 +744,12 @@ export default class BOBasePage extends CommonPage implements BOBasePagePageInte
    * @returns {Promise<string|null>}
    */
   async addCurrentPageToQuickAccess(page: Page, pageName: string): Promise<string | null> {
-    await this.dialogListener(page, true, pageName);
     await this.waitForSelectorAndClick(page, this.quickAccessDropdownToggle);
     await this.waitForSelectorAndClick(page, this.quickAddCurrentLink);
+
+    await page.locator(this.quickAccessAddModal).waitFor({state: 'visible'});
+    await page.locator(this.quickAccessAddModalNameInput).fill(pageName);
+    await this.waitForSelectorAndClick(page, this.quickAccessAddModalSaveButton);
 
     return page.locator(this.growlDiv).textContent();
   }

--- a/src/pages/BO/BOBasePage.ts
+++ b/src/pages/BO/BOBasePage.ts
@@ -744,12 +744,21 @@ export default class BOBasePage extends CommonPage implements BOBasePagePageInte
    * @returns {Promise<string|null>}
    */
   async addCurrentPageToQuickAccess(page: Page, pageName: string): Promise<string | null> {
+    // Register dialog handler for legacy window.prompt() behavior (≤ 9.1.x)
+    await this.dialogListener(page, true, pageName);
     await this.waitForSelectorAndClick(page, this.quickAccessDropdownToggle);
     await this.waitForSelectorAndClick(page, this.quickAddCurrentLink);
 
-    await page.locator(this.quickAccessAddModal).waitFor({state: 'visible'});
-    await page.locator(this.quickAccessAddModalNameInput).fill(pageName);
-    await this.waitForSelectorAndClick(page, this.quickAccessAddModalSaveButton);
+    // If the modal is present (develop+), interact with it; otherwise the dialogListener handled the prompt
+    const isModalVisible = await page.locator(this.quickAccessAddModal)
+      .waitFor({state: 'visible', timeout: 2000})
+      .then(() => true)
+      .catch(() => false);
+
+    if (isModalVisible) {
+      await page.locator(this.quickAccessAddModalNameInput).fill(pageName);
+      await this.waitForSelectorAndClick(page, this.quickAccessAddModalSaveButton);
+    }
 
     return page.locator(this.growlDiv).textContent();
   }


### PR DESCRIPTION
## Context

Following [PrestaShop/PrestaShop#41608](https://github.com/PrestaShop/PrestaShop/pull/41608), the native `window.prompt()` used when adding the current page to Quick Access from the BO header has been replaced by a PrestaShop modal.

The existing `addCurrentPageToQuickAccess` method in `BOBasePage` relied on `dialogListener` (a `page.on('dialog', ...)` Playwright handler) to intercept the native browser dialog. Since the dialog no longer appears, this handler never fires and the method fails silently.

## Changes

**`src/pages/BO/BOBasePage.ts`**

- Removed `dialogListener` call (no more `window.prompt()` to intercept)
- Added 3 selectors targeting the new modal elements: `#quick-access-add-modal`, `#quick-access-name`, `#quick-access-save-btn`
- Updated `addCurrentPageToQuickAccess` to:
  1. Wait for the modal to be visible after clicking "Add current page to Quick Access"
  2. Fill the name input with the provided `pageName`
  3. Click the Save button

## Merge order

This PR must be merged **before** the related core PR so that `tests/UI/package-lock.json` can be updated to pick up the new `#main` reference.

## Related PR

- PrestaShop/PrestaShop#41608