### PR TITLE
Add setInvalidDiscount to BO customer groups create page object

### DIFF
--- a/src/interfaces/BO/shopParameters/customerSettings/groups/create.ts
+++ b/src/interfaces/BO/shopParameters/customerSettings/groups/create.ts
@@ -9,5 +9,6 @@ export interface BOCustomerGroupsCreatePageInterface extends BOBasePagePageInter
   createEditGroup(page: Page, groupData: FakerGroup): Promise<string>;
   getValue(page: Page, inputName: string, languageId?: number): Promise<string>;
   setDiscount(page: Page, discount: number): Promise<string>;
+  setInvalidDiscount(page: Page, groupData: FakerGroup, discount: string): Promise<string>;
   setPriceDisplayMethod(page: Page, priceDisplayMethod: string): Promise<string>;
 }

--- a/src/versions/develop/pages/BO/shopParameters/customerSettings/groups/create.ts
+++ b/src/versions/develop/pages/BO/shopParameters/customerSettings/groups/create.ts
@@ -101,6 +101,31 @@ class BOCustomerGroupsCreatePage extends BOBasePage implements BOCustomerGroupsC
   }
 
   /**
+   * Fill the group form with an invalid discount (banned symbols) and save to get the error message
+   * @param page {Page} Browser tab
+   * @param groupData {FakerGroup} Data to set on create/edit form (name, price display method...)
+   * @param discount {string} Invalid discount value containing banned symbols
+   * @returns {Promise<string>}
+   */
+  async setInvalidDiscount(page: Page, groupData: FakerGroup, discount: string): Promise<string> {
+    await this.changeLanguage(page, 1);
+    await this.setValue(page, this.nameInput(1), groupData.name);
+
+    await this.changeLanguage(page, 2);
+    await this.setValue(page, this.nameInput(2), groupData.frName);
+
+    await this.setValue(page, this.discountInput, discount);
+
+    await this.selectByVisibleText(page, this.priceDisplayMethodSelect, groupData.priceDisplayMethod);
+
+    await this.setChecked(page, this.showPricesToggle(groupData.shownPrices ? 'on' : 'off'));
+
+    await this.clickAndWaitForURL(page, this.saveButton);
+
+    return this.getAlertDangerBlockParagraphContent(page);
+  }
+
+  /**
    * Set discount and save the form
    * @param page {Page} Browser tab
    * @param discount {number}

--- a/src/versions/develop/pages/BO/shopParameters/customerSettings/groups/create.ts
+++ b/src/versions/develop/pages/BO/shopParameters/customerSettings/groups/create.ts
@@ -1,3 +1,4 @@
+import dataLanguages from '@data/demo/languages';
 import type FakerGroup from '@data/faker/group';
 import {type BOCustomerGroupsCreatePageInterface} from '@interfaces/BO/shopParameters/customerSettings/groups/create';
 import BOBasePage from '@pages/BO/BOBasePage';
@@ -108,11 +109,11 @@ class BOCustomerGroupsCreatePage extends BOBasePage implements BOCustomerGroupsC
    * @returns {Promise<string>}
    */
   async setInvalidDiscount(page: Page, groupData: FakerGroup, discount: string): Promise<string> {
-    await this.changeLanguage(page, 1);
-    await this.setValue(page, this.nameInput(1), groupData.name);
+    await this.changeLanguage(page, dataLanguages.english.id);
+    await this.setValue(page, this.nameInput(dataLanguages.english.id), groupData.name);
 
-    await this.changeLanguage(page, 2);
-    await this.setValue(page, this.nameInput(2), groupData.frName);
+    await this.changeLanguage(page, dataLanguages.french.id);
+    await this.setValue(page, this.nameInput(dataLanguages.french.id), groupData.frName);
 
     await this.setValue(page, this.discountInput, discount);
 


### PR DESCRIPTION
## Description

Adds a `setInvalidDiscount(page, groupData, discount)` method to the BO **Customer Settings > Groups** create page object. It fills the group form with an invalid discount value (banned symbols) and saves, returning the danger alert content.

This is the page-object support required by a core regression test for [PrestaShop/PrestaShop#28415](https://github.com/PrestaShop/PrestaShop/issues/28415): submitting a group with an invalid discount must keep the user on the form and display the error instead of redirecting to the groups list.

## Changes

- `interfaces/.../customerSettings/groups/create.ts` — declare `setInvalidDiscount`
- `versions/develop/pages/.../customerSettings/groups/create.ts` — implement it (reuses existing selectors + `getAlertDangerBlockParagraphContent`)

## Checks

- `npm run build` (tsc): passing
- `eslint` on changed files: passing

## Related PRs

- Core: PrestaShop/PrestaShop#41663 (consumes the new page-object method in its regression test).
