### PR TITLE
Add getDefaultCustomerGroupOptions to BO customer create page

### DIFF
--- a/src/interfaces/BO/customers/create.ts
+++ b/src/interfaces/BO/customers/create.ts
@@ -9,6 +9,7 @@ export interface BOCustomersCreatePageInterface extends BOBasePagePageInterface 
 
   createEditB2BCustomer(page: Page, customerData: FakerCustomer): Promise<string>;
   createEditCustomer(page: Frame | Page, customerData: FakerCustomer, waitForNavigation?: boolean): Promise<string>;
+  getDefaultCustomerGroupOptions(page: Frame | Page): Promise<string[]>;
   getRequiredInputErrorMessage(page: Frame | Page, input:string): Promise<string>;
   enableGuestAccount(page: Frame | Page, guestAccount: boolean): Promise<void>;
   isDefaultCustomerGroupDisabled(page: Frame | Page): Promise<boolean>;

--- a/src/versions/develop/pages/BO/customers/create.ts
+++ b/src/versions/develop/pages/BO/customers/create.ts
@@ -185,6 +185,15 @@ class BOCustomersCreatePage extends BOBasePage implements BOCustomersCreatePageI
   }
 
   /**
+   * Get the list of options available in the default customer group dropdown
+   * @param page {Frame|Page} Browser tab
+   * @return {Promise<string[]>}
+   */
+  async getDefaultCustomerGroupOptions(page: Frame | Page): Promise<string[]> {
+    return page.locator(`${this.defaultCustomerGroupSelect} option`).allTextContents();
+  }
+
+  /**
    * Get required input error message
    * @param page  {Frame|Page} Browser tab
    * @param input {string} The input to get error message from


### PR DESCRIPTION
## Description

Adds `BOCustomersCreatePage.getDefaultCustomerGroupOptions()` which returns the list of option labels available in the customer form's **Default customer group** dropdown (`select#customer_default_group_id`).

This getter is needed so test campaigns can assert *which* customer groups are displayed in the customer add/edit form — in particular to cover the regression where groups sharing the same name were not all listed.

## Type

- New page object method (non-breaking, additive)

## Related

- Core PR: PrestaShop/PrestaShop#41667
- Fixes the missing page-object method required by its regression campaign (`tests/UI/campaigns/regression/customers/duplicateGroupNamesInCustomerForm.ts`) for PrestaShop/PrestaShop#28977.
