### PR TITLE
Verify success flash on states toggle (develop) and keep growl behavior for 9.1.x

### DIFF
--- a/src/pages/BO/international/locations/states/index.ts
+++ b/src/pages/BO/international/locations/states/index.ts
@@ -1,8 +1,15 @@
 import {type BOStatesPageInterface} from '@interfaces/BO/international/locations/states';
+import testContext from '@utils/test';
+import semver from 'semver';
+
+const psVersion = testContext.getPSVersion();
 
 /* eslint-disable global-require, @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
 function requirePage(): BOStatesPageInterface {
-  return require('@versions/develop/pages/BO/international/locations/states');
+  if (semver.lt(psVersion, '9.2.0')) {
+    return require('@versions/9.1/pages/BO/international/locations/states').boStatesPage;
+  }
+  return require('@versions/develop/pages/BO/international/locations/states').boStatesPage;
 }
 /* eslint-enable global-require, @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires */
 

--- a/src/versions/9.1/pages/BO/international/locations/states/index.ts
+++ b/src/versions/9.1/pages/BO/international/locations/states/index.ts
@@ -1,0 +1,35 @@
+import {type BOStatesPageInterface} from '@interfaces/BO/international/locations/states';
+import {type Page} from '@playwright/test';
+import {BOStatesPage as BOStatesPageVersion} from '@versions/develop/pages/BO/international/locations/states';
+
+/**
+ * States page, contains functions that can be used on the page
+ * @class
+ * @extends BOStatesPageVersion
+ */
+class BOStatesPage extends BOStatesPageVersion implements BOStatesPageInterface {
+  /**
+   * Set state status
+   * @param page {Page} Browser tab
+   * @param row {number} Row on table
+   * @param wantedStatus {boolean} True if we need to enable status, false if not
+   * @return {Promise<boolean>}, true if the status has been successfully updated
+   */
+  async setStateStatus(page: Page, row: number, wantedStatus: boolean): Promise<boolean> {
+    if (wantedStatus !== await this.getStateStatus(page, row)) {
+      // In 9.1.x the toggle is an async action displaying a growl message (no page reload)
+      const [message] = await Promise.all([
+        this.getGrowlMessageContent(page),
+        page.locator(this.tableColumnStatusToggle(row)).click(),
+      ]);
+
+      await this.closeGrowlMessage(page);
+      return message === this.successfulUpdateStatusMessage;
+    }
+
+    return false;
+  }
+}
+
+const boStatesPage = new BOStatesPage();
+export {boStatesPage, BOStatesPage};

--- a/src/versions/develop/pages/BO/international/locations/states/index.ts
+++ b/src/versions/develop/pages/BO/international/locations/states/index.ts
@@ -10,7 +10,7 @@ import {type Page} from '@playwright/test';
 class BOStatesPage extends BOBasePage implements BOStatesPageInterface {
   public readonly pageTitle: string;
 
-  private readonly successfulUpdateStatusMessage: string;
+  protected readonly successfulUpdateStatusMessage: string;
 
   private readonly addNewStateLink: string;
 
@@ -64,7 +64,7 @@ class BOStatesPage extends BOBasePage implements BOStatesPageInterface {
 
   private readonly tableColumnStatusLink: (row: number) => string;
 
-  private readonly tableColumnStatusToggle: (row: number) => string;
+  protected readonly tableColumnStatusToggle: (row: number) => string;
 
   private readonly tableColumnStatusToggleInput: (row: number) => string;
 
@@ -340,13 +340,16 @@ class BOStatesPage extends BOBasePage implements BOStatesPageInterface {
    * @param page {Page} Browser tab
    * @param row {number} Row on table
    * @param wantedStatus {boolean} True if we need to enable status, false if not
-   * @return {Promise<boolean>}, true if click has been performed
+   * @return {Promise<boolean>}, true if the status has been successfully updated
    */
   async setStateStatus(page: Page, row: number, wantedStatus: boolean): Promise<boolean> {
     if (wantedStatus !== await this.getStateStatus(page, row)) {
-      // The toggle submits a form and reloads the page (flash message), no growl is shown
-      await page.locator(this.tableColumnStatusToggle(row)).click();
-      return true;
+      // The toggle submits a form and reloads the page with a flash message (no growl is shown)
+      await this.clickAndWaitForURL(page, this.tableColumnStatusToggle(row));
+
+      const message = await this.getAlertSuccessBlockParagraphContent(page);
+
+      return message.includes(this.successfulUpdateStatusMessage);
     }
 
     return false;
@@ -563,4 +566,5 @@ class BOStatesPage extends BOBasePage implements BOStatesPageInterface {
   }
 }
 
-module.exports = new BOStatesPage();
+const boStatesPage = new BOStatesPage();
+export {boStatesPage, BOStatesPage};

--- a/src/versions/develop/pages/BO/international/locations/states/index.ts
+++ b/src/versions/develop/pages/BO/international/locations/states/index.ts
@@ -344,14 +344,9 @@ class BOStatesPage extends BOBasePage implements BOStatesPageInterface {
    */
   async setStateStatus(page: Page, row: number, wantedStatus: boolean): Promise<boolean> {
     if (wantedStatus !== await this.getStateStatus(page, row)) {
-      // Click and wait for message
-      const [message] = await Promise.all([
-        this.getGrowlMessageContent(page),
-        page.locator(this.tableColumnStatusToggle(row)).click(),
-      ]);
-
-      await this.closeGrowlMessage(page);
-      return message === this.successfulUpdateStatusMessage;
+      // The toggle submits a form and reloads the page (flash message), no growl is shown
+      await page.locator(this.tableColumnStatusToggle(row)).click();
+      return true;
     }
 
     return false;


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | main
| Description?      | The states grid status toggle was migrated (in the related core PR) from an async toggle (`JsonResponse` + growl message) to a form POST that redirects and reloads the page with a flash message — the same pattern already used by the zones grid. As a result no `.growl-message` is shown anymore, so `setStateStatus` timed out waiting for it (`Timeout 10000ms exceeded waiting for locator('.growl-message')`).<br><br>**This change only lands on `develop` (9.2.0).** Since the test library has no `9.1` version of this page object, the `develop` one applies to `9.1.x` by default — where the toggle is still the async growl action. This PR therefore:<br>• **`develop`**: `setStateStatus` now follows the redirect (`clickAndWaitForURL`) and asserts the success **flash** message instead of blindly returning `true`.<br>• **`9.1` (new override)**: keeps the previous **growl**-based behavior, so 9.1.x tests still pass.<br>• **resolver**: routes between the two via `semver` (`< 9.2.0` → `9.1`, otherwise `develop`).
| Type?             | bug fix
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | Run the campaign `BO - International - States : Filter and quick edit` (`03_states/01_filterAndQuickEditStates`) against the related core PR branch (9.2.0/develop). The "Quick edit state" tests (enable/disable) must pass. On a 9.1.x shop, the same campaign must keep passing through the `9.1` override.
| Fixed issue or discussion?     | N/A
| Related PRs       | PrestaShop/PrestaShop#41620

## Merge order

This PR must be merged **before** the related core PR's CI can go green. Once merged, `tests/UI/package-lock.json` in the core PR must be regenerated to pick up the new `#main` reference of `@prestashop-core/ui-testing` (the core points to `…/ui-testing-library#main`, not a tagged release, so no library release is required).
