### PR TITLE
Add cart_rule feature flag to BOFeatureFlag page

### DIFF
--- a/src/interfaces/BO/advancedParameters/featureFlag.ts
+++ b/src/interfaces/BO/advancedParameters/featureFlag.ts
@@ -4,6 +4,7 @@ import {type Page} from '@playwright/test';
 export interface BOFeatureFlagInterface extends BOBasePagePageInterface {
   readonly featureFlagAdminAPI: string;
   readonly featureFlagAdminAPIMultistore: string;
+  readonly featureFlagCartRule: string;
   readonly featureFlagDiscount: string;
   readonly featureFlagImprovedShipment: string;
   readonly featureFlagProductPageV2: string;

--- a/src/versions/develop/pages/BO/advancedParameters/featureFlag.ts
+++ b/src/versions/develop/pages/BO/advancedParameters/featureFlag.ts
@@ -18,6 +18,8 @@ class BOFeatureFlag extends BOBasePage implements BOFeatureFlagInterface {
 
   public readonly featureFlagImprovedShipment: string;
 
+  public readonly featureFlagCartRule: string;
+
   public readonly featureFlagDiscount: string;
 
   public readonly featureFlagMultipleImageFormats: string;
@@ -48,6 +50,7 @@ class BOFeatureFlag extends BOBasePage implements BOFeatureFlagInterface {
     this.featureFlagAdminAPI = 'admin_api';
     this.featureFlagAdminAPIMultistore = 'admin_api_multistore';
     this.featureFlagImprovedShipment = 'improved_shipment';
+    this.featureFlagCartRule = 'cart_rule';
     this.featureFlagDiscount = 'discount';
     // Selectors
     this.featureFlagSwitchButton = (status: string, feature: string, toggle: number) => `#feature_flag_${
@@ -78,6 +81,9 @@ class BOFeatureFlag extends BOBasePage implements BOFeatureFlagInterface {
         isStable = false;
         break;
       case this.featureFlagImprovedShipment:
+        isStable = false;
+        break;
+      case this.featureFlagCartRule:
         isStable = false;
         break;
       case this.featureFlagDiscount:


### PR DESCRIPTION
## Description

Adds the `cart_rule` feature flag (id `cart_rule`) to the `BOFeatureFlag` page object so UI tests can enable/disable the experimental **Cart rules** feature flag, which exists in PrestaShop **9.0.x**.

Without it, `boFeatureFlagPage.setFeatureFlag(page, 'cart_rule', ...)` throws `The feature flag cart_rule is not defined`.

Changes:
- `src/interfaces/BO/advancedParameters/featureFlag.ts`: add `readonly featureFlagCartRule: string;`
- `src/versions/develop/pages/BO/advancedParameters/featureFlag.ts`: declare + assign `featureFlagCartRule = 'cart_rule'` and add the `switch` case (beta / experimental).

## Related

Required by PrestaShop/PrestaShop#34737 fix (UI test enabling the `cart_rule` flag on the migrated "Add new cart rule" page).

`npm run build` and `eslint` pass.