### PR TITLE
TEST-12861 & TEST-12862 - Add Top Contributors and New Contributors to BOWallOfFamePage

### DIFF
--- a/src/interfaces/BO/community/wallOfFame.ts
+++ b/src/interfaces/BO/community/wallOfFame.ts
@@ -21,4 +21,15 @@ export interface BOWallOfFamePageInterface extends BOBasePagePageInterface {
   isContributorModalAvatarVisible(page: Page): Promise<boolean>;
   closeContributorModal(page: Page): Promise<void>;
   clickViewAllContributorsButton(page: Page): Promise<Page>;
+
+  // New Contributors
+  getNewContributorsSectionTitle(page: Page): Promise<string>;
+  getNewContributorsSectionDescription(page: Page): Promise<string>;
+  getVisibleNewContributorsCount(page: Page): Promise<number>;
+  getVisibleNewContributorNames(page: Page): Promise<string[]>;
+  isFirstNewContributorAvatarVisible(page: Page): Promise<boolean>;
+  clickNextNewContributorButton(page: Page): Promise<void>;
+  clickPreviousNewContributorButton(page: Page): Promise<void>;
+  isNextNewContributorButtonDisabled(page: Page): Promise<boolean>;
+  isPreviousNewContributorButtonDisabled(page: Page): Promise<boolean>;
 }

--- a/src/interfaces/BO/community/wallOfFame.ts
+++ b/src/interfaces/BO/community/wallOfFame.ts
@@ -3,33 +3,27 @@ import {type Page} from '@playwright/test';
 
 export interface BOWallOfFamePageInterface extends BOBasePagePageInterface {
   readonly pageTitle: string;
+  clickCompanyActionButton(page: Page, companyName: string): Promise<Page>;
+  clickContributorActionButton(page: Page, contributorName: string): Promise<void>;
+  clickNextNewContributorButton(page: Page): Promise<void>;
+  clickPreviousNewContributorButton(page: Page): Promise<void>;
+  clickViewAllContributorsButton(page: Page): Promise<Page>;
+  closeContributorModal(page: Page): Promise<void>;
   getContributionPercentage(page: Page, contributor: 'PrestaShop' | 'Community'): Promise<number>;
-
-  // Top Companies
+  getContributorModalGitHubUsername(page: Page): Promise<string>;
+  getContributorModalName(page: Page): Promise<string>;
+  getNewContributorsSectionDescription(page: Page): Promise<string>;
+  getNewContributorsSectionTitle(page: Page): Promise<string>;
   getTopCompaniesCardTitle(page: Page): Promise<string>;
   getTopCompaniesDescription(page: Page): Promise<string>;
   getTopCompaniesTableColumnHeaders(page: Page): Promise<string[]>;
-  clickCompanyActionButton(page: Page, companyName: string): Promise<Page>;
-
-  // Top Contributors
   getTopContributorsCardTitle(page: Page): Promise<string>;
   getTopContributorsDescription(page: Page): Promise<string>;
   getTopContributorsTableColumnHeaders(page: Page): Promise<string[]>;
-  clickContributorActionButton(page: Page, contributorName: string): Promise<void>;
-  getContributorModalName(page: Page): Promise<string>;
-  getContributorModalGitHubUsername(page: Page): Promise<string>;
-  isContributorModalAvatarVisible(page: Page): Promise<boolean>;
-  closeContributorModal(page: Page): Promise<void>;
-  clickViewAllContributorsButton(page: Page): Promise<Page>;
-
-  // New Contributors
-  getNewContributorsSectionTitle(page: Page): Promise<string>;
-  getNewContributorsSectionDescription(page: Page): Promise<string>;
-  getVisibleNewContributorsCount(page: Page): Promise<number>;
   getVisibleNewContributorNames(page: Page): Promise<string[]>;
+  getVisibleNewContributorsCount(page: Page): Promise<number>;
+  isContributorModalAvatarVisible(page: Page): Promise<boolean>;
   isFirstNewContributorAvatarVisible(page: Page): Promise<boolean>;
-  clickNextNewContributorButton(page: Page): Promise<void>;
-  clickPreviousNewContributorButton(page: Page): Promise<void>;
   isNextNewContributorButtonDisabled(page: Page): Promise<boolean>;
   isPreviousNewContributorButtonDisabled(page: Page): Promise<boolean>;
 }

--- a/src/interfaces/BO/community/wallOfFame.ts
+++ b/src/interfaces/BO/community/wallOfFame.ts
@@ -5,8 +5,20 @@ export interface BOWallOfFamePageInterface extends BOBasePagePageInterface {
   readonly pageTitle: string;
   getContributionPercentage(page: Page, contributor: 'PrestaShop' | 'Community'): Promise<number>;
 
-  clickCompanyActionButton(page: Page, companyName: string): Promise<Page>;
+  // Top Companies
   getTopCompaniesCardTitle(page: Page): Promise<string>;
   getTopCompaniesDescription(page: Page): Promise<string>;
   getTopCompaniesTableColumnHeaders(page: Page): Promise<string[]>;
+  clickCompanyActionButton(page: Page, companyName: string): Promise<Page>;
+
+  // Top Contributors
+  getTopContributorsCardTitle(page: Page): Promise<string>;
+  getTopContributorsDescription(page: Page): Promise<string>;
+  getTopContributorsTableColumnHeaders(page: Page): Promise<string[]>;
+  clickContributorActionButton(page: Page, contributorName: string): Promise<void>;
+  getContributorModalName(page: Page): Promise<string>;
+  getContributorModalGitHubUsername(page: Page): Promise<string>;
+  isContributorModalAvatarVisible(page: Page): Promise<boolean>;
+  closeContributorModal(page: Page): Promise<void>;
+  clickViewAllContributorsButton(page: Page): Promise<Page>;
 }

--- a/src/versions/develop/pages/BO/community/wallOfFame.ts
+++ b/src/versions/develop/pages/BO/community/wallOfFame.ts
@@ -26,6 +26,27 @@ class BOWallOfFamePage extends BOBasePage implements BOWallOfFamePageInterface {
 
   private readonly topCompaniesTableHeaders: string;
 
+  // Top Contributors card selectors
+  private readonly topContributorsCard: string;
+
+  private readonly topContributorsCardTitle: string;
+
+  private readonly topContributorsDescription: string;
+
+  private readonly topContributorsTableHeaders: string;
+
+  private readonly contributorModal: string;
+
+  private readonly contributorModalName: string;
+
+  private readonly contributorModalGitHubUsername: string;
+
+  private readonly contributorModalAvatar: string;
+
+  private readonly contributorModalCloseButton: string;
+
+  private readonly viewAllContributorsButton: string;
+
   /**
    * @constructs
    * Setting up texts and selectors to use on Wall of Fame page
@@ -46,6 +67,20 @@ class BOWallOfFamePage extends BOBasePage implements BOWallOfFamePageInterface {
     this.topCompaniesDescription = `${this.topCompaniesCard} .wof-top-card__description`;
     // puik-table renders <th class="puik-table__head__row__item ...">
     this.topCompaniesTableHeaders = `${this.topCompaniesCard} .puik-table__head__row__item`;
+
+    // Top Contributors card — second .wof-top-card
+    this.topContributorsCard = '.wof-top-section__cards .wof-top-card:nth-child(2)';
+    this.topContributorsCardTitle = `${this.topContributorsCard} .wof-top-card__title`;
+    this.topContributorsDescription = `${this.topContributorsCard} .wof-top-card__description`;
+    this.topContributorsTableHeaders = `${this.topContributorsCard} .puik-table__head__row__item`;
+    this.viewAllContributorsButton = `${this.topContributorsCard} .wof-top-card__footer a`;
+
+    // Contributor modal (PUIK modal component)
+    this.contributorModal = '.puik-modal';
+    this.contributorModalName = `${this.contributorModal} .wof-contributor-modal__name`;
+    this.contributorModalGitHubUsername = `${this.contributorModal} .wof-contributor-modal__username`;
+    this.contributorModalAvatar = `${this.contributorModal} img.wof-contributor-modal__avatar`;
+    this.contributorModalCloseButton = `${this.contributorModal} .puik-modal__close`;
   }
 
   /**
@@ -101,6 +136,80 @@ class BOWallOfFamePage extends BOBasePage implements BOWallOfFamePageInterface {
     return this.openLinkWithTargetBlank(
       page,
       this.companyActionLink(companyName),
+      'body',
+      'domcontentloaded',
+      false,
+    );
+  }
+
+  /**
+   * Get the Top Contributors card title text
+   */
+  async getTopContributorsCardTitle(page: Page): Promise<string> {
+    return this.getTextContent(page, this.topContributorsCardTitle);
+  }
+
+  /**
+   * Get the Top Contributors card description text
+   */
+  async getTopContributorsDescription(page: Page): Promise<string> {
+    return this.getTextContent(page, this.topContributorsDescription);
+  }
+
+  /**
+   * Get the column header labels of the Top Contributors table
+   */
+  async getTopContributorsTableColumnHeaders(page: Page): Promise<string[]> {
+    await this.waitForVisibleSelector(page, this.topContributorsTableHeaders, 15000);
+    const rawTexts = await page.locator(this.topContributorsTableHeaders).allTextContents();
+
+    return rawTexts.map((t: string) => t.replace(/\s+/g, ' ').trim()).filter((t: string) => t.length > 0);
+  }
+
+  /**
+   * Click the action button for a given contributor to open the modal
+   */
+  async clickContributorActionButton(page: Page, contributorName: string): Promise<void> {
+    await page.locator(`${this.topContributorsCard} tr:has-text("${contributorName}") button`).click();
+    await this.waitForVisibleSelector(page, this.contributorModal);
+  }
+
+  /**
+   * Get the contributor name displayed in the modal
+   */
+  async getContributorModalName(page: Page): Promise<string> {
+    return this.getTextContent(page, this.contributorModalName);
+  }
+
+  /**
+   * Get the GitHub username displayed in the modal
+   */
+  async getContributorModalGitHubUsername(page: Page): Promise<string> {
+    return this.getTextContent(page, this.contributorModalGitHubUsername);
+  }
+
+  /**
+   * Check if the contributor avatar image is visible in the modal
+   */
+  async isContributorModalAvatarVisible(page: Page): Promise<boolean> {
+    return this.elementVisible(page, this.contributorModalAvatar, 3000);
+  }
+
+  /**
+   * Close the contributor modal by clicking the close button
+   */
+  async closeContributorModal(page: Page): Promise<void> {
+    await this.waitForSelectorAndClick(page, this.contributorModalCloseButton);
+    await this.waitForHiddenSelector(page, this.contributorModal);
+  }
+
+  /**
+   * Click the "View all" button in the Top Contributors card and return the new tab
+   */
+  async clickViewAllContributorsButton(page: Page): Promise<Page> {
+    return this.openLinkWithTargetBlank(
+      page,
+      this.viewAllContributorsButton,
       'body',
       'domcontentloaded',
       false,

--- a/src/versions/develop/pages/BO/community/wallOfFame.ts
+++ b/src/versions/develop/pages/BO/community/wallOfFame.ts
@@ -47,6 +47,23 @@ class BOWallOfFamePage extends BOBasePage implements BOWallOfFamePageInterface {
 
   private readonly viewAllContributorsButton: string;
 
+  // New Contributors section selectors
+  private readonly newContributorsSection: string;
+
+  private readonly newContributorsSectionTitle: string;
+
+  private readonly newContributorsSectionDescription: string;
+
+  private readonly newContributorCards: string;
+
+  private readonly newContributorName: string;
+
+  private readonly newContributorAvatar: string;
+
+  private readonly nextNewContributorButton: string;
+
+  private readonly previousNewContributorButton: string;
+
   /**
    * @constructs
    * Setting up texts and selectors to use on Wall of Fame page
@@ -74,6 +91,16 @@ class BOWallOfFamePage extends BOBasePage implements BOWallOfFamePageInterface {
     this.topContributorsDescription = `${this.topContributorsCard} .wof-top-card__description`;
     this.topContributorsTableHeaders = `${this.topContributorsCard} .puik-table__head__row__item`;
     this.viewAllContributorsButton = `${this.topContributorsCard} .wof-top-card__footer a`;
+
+    // New Contributors section
+    this.newContributorsSection = '.wof-new-contributors-section';
+    this.newContributorsSectionTitle = `${this.newContributorsSection} .wof-new-contributors-section__title`;
+    this.newContributorsSectionDescription = `${this.newContributorsSection} .wof-new-contributors-section__description`;
+    this.newContributorCards = `${this.newContributorsSection} .wof-contributor-card`;
+    this.newContributorName = `${this.newContributorCards} .wof-contributor-card__name`;
+    this.newContributorAvatar = `${this.newContributorCards}:first-child img.wof-contributor-card__avatar`;
+    this.nextNewContributorButton = `${this.newContributorsSection} button.wof-new-contributors__next`;
+    this.previousNewContributorButton = `${this.newContributorsSection} button.wof-new-contributors__prev`;
 
     // Contributor modal (PUIK modal component)
     this.contributorModal = '.puik-modal';
@@ -214,6 +241,74 @@ class BOWallOfFamePage extends BOBasePage implements BOWallOfFamePageInterface {
       'domcontentloaded',
       false,
     );
+  }
+
+  /**
+   * Get the New Contributors section title
+   */
+  async getNewContributorsSectionTitle(page: Page): Promise<string> {
+    return this.getTextContent(page, this.newContributorsSectionTitle);
+  }
+
+  /**
+   * Get the New Contributors section description
+   */
+  async getNewContributorsSectionDescription(page: Page): Promise<string> {
+    return this.getTextContent(page, this.newContributorsSectionDescription);
+  }
+
+  /**
+   * Get the number of visible contributor cards
+   */
+  async getVisibleNewContributorsCount(page: Page): Promise<number> {
+    await this.waitForVisibleSelector(page, this.newContributorCards, 15000);
+
+    return page.locator(this.newContributorCards).count();
+  }
+
+  /**
+   * Get the names of all currently visible new contributors
+   */
+  async getVisibleNewContributorNames(page: Page): Promise<string[]> {
+    await this.waitForVisibleSelector(page, this.newContributorName, 15000);
+    const rawTexts = await page.locator(this.newContributorName).allTextContents();
+
+    return rawTexts.map((t: string) => t.trim()).filter((t: string) => t.length > 0);
+  }
+
+  /**
+   * Check if the avatar of the first visible new contributor is visible
+   */
+  async isFirstNewContributorAvatarVisible(page: Page): Promise<boolean> {
+    return this.elementVisible(page, this.newContributorAvatar, 3000);
+  }
+
+  /**
+   * Click the next (→) button in the New Contributors carousel
+   */
+  async clickNextNewContributorButton(page: Page): Promise<void> {
+    await this.waitForSelectorAndClick(page, this.nextNewContributorButton);
+  }
+
+  /**
+   * Click the previous (←) button in the New Contributors carousel
+   */
+  async clickPreviousNewContributorButton(page: Page): Promise<void> {
+    await this.waitForSelectorAndClick(page, this.previousNewContributorButton);
+  }
+
+  /**
+   * Check if the next (→) button is disabled
+   */
+  async isNextNewContributorButtonDisabled(page: Page): Promise<boolean> {
+    return this.elementNotVisible(page, `${this.nextNewContributorButton}:not([disabled])`, 2000);
+  }
+
+  /**
+   * Check if the previous (←) button is disabled
+   */
+  async isPreviousNewContributorButtonDisabled(page: Page): Promise<boolean> {
+    return this.elementNotVisible(page, `${this.previousNewContributorButton}:not([disabled])`, 2000);
   }
 }
 


### PR DESCRIPTION
## Summary

- Add **Top Contributors** card methods to `BOWallOfFamePage`: card title/description, table headers, contributor modal (open/read name+username+avatar/close), View all button
- Add **New Contributors** carousel methods to `BOWallOfFamePage`: section title/description, visible contributors count/names/avatar, next/previous buttons, disabled state checks
- Update `BOWallOfFamePageInterface` with all new method signatures

## Related PRs

- https://github.com/PrestaShop/PrestaShop/pull/41686

## Test plan

Launch test