### PR TITLE
Add customer group-access page-object helpers

### DIFF
--- a/src/interfaces/BO/customers/create.ts
+++ b/src/interfaces/BO/customers/create.ts
@@ -7,10 +7,13 @@ export interface BOCustomersCreatePageInterface extends BOBasePagePageInterface 
   readonly pageTitleEdit: string;
   readonly requiredFieldErrorMessage: string;
 
+  clickOnSaveButton(page: Frame | Page): Promise<void>;
   createEditB2BCustomer(page: Page, customerData: FakerCustomer): Promise<string>;
   createEditCustomer(page: Frame | Page, customerData: FakerCustomer, waitForNavigation?: boolean): Promise<string>;
   getDefaultCustomerGroupOptions(page: Frame | Page): Promise<string[]>;
+  getGroupAccessErrorMessage(page: Frame | Page): Promise<string>;
   getRequiredInputErrorMessage(page: Frame | Page, input:string): Promise<string>;
+  uncheckAllGroupAccess(page: Frame | Page): Promise<void>;
   enableGuestAccount(page: Frame | Page, guestAccount: boolean): Promise<void>;
   isDefaultCustomerGroupDisabled(page: Frame | Page): Promise<boolean>;
   isDefaultCustomerGroupEnabled(page: Frame | Page): Promise<boolean>;

--- a/src/versions/develop/pages/BO/customers/create.ts
+++ b/src/versions/develop/pages/BO/customers/create.ts
@@ -55,6 +55,8 @@ class BOCustomersCreatePage extends BOBasePage implements BOCustomersCreatePageI
 
   private readonly selectAllGroupAccessCheckbox: string;
 
+  private readonly groupAccessErrorMessage: string;
+
   private readonly defaultCustomerGroupSelect: string;
 
   private readonly saveCustomerButton: string;
@@ -94,6 +96,7 @@ class BOCustomersCreatePage extends BOBasePage implements BOCustomersCreatePageI
     this.customerCheckbox = this.groupAccessCheckbox(2);
 
     this.selectAllGroupAccessCheckbox = 'input.js-choice-table-select-all';
+    this.groupAccessErrorMessage = '.js-at-least-one-group-error';
     this.defaultCustomerGroupSelect = 'select#customer_default_group_id';
     this.saveCustomerButton = '#save-button';
   }
@@ -339,6 +342,35 @@ class BOCustomersCreatePage extends BOBasePage implements BOCustomersCreatePageI
       default:
         throw new Error(`${customerGroup} was not found as a group access`);
     }
+  }
+
+  /**
+   * Uncheck all group access checkboxes (visitor/guest/customer)
+   * @param page {Frame|Page} Browser tab
+   * @return {Promise<void>}
+   */
+  async uncheckAllGroupAccess(page: Frame | Page): Promise<void> {
+    await this.setCheckedWithIcon(page, this.visitorCheckbox, false);
+    await this.setCheckedWithIcon(page, this.guestCheckbox, false);
+    await this.setCheckedWithIcon(page, this.customerCheckbox, false);
+  }
+
+  /**
+   * Click on save button without waiting for navigation (used when validation blocks the save)
+   * @param page {Frame|Page} Browser tab
+   * @return {Promise<void>}
+   */
+  async clickOnSaveButton(page: Frame | Page): Promise<void> {
+    await this.waitForSelectorAndClick(page, this.saveCustomerButton);
+  }
+
+  /**
+   * Get the inline group access error message
+   * @param page {Frame|Page} Browser tab
+   * @return {Promise<string>}
+   */
+  async getGroupAccessErrorMessage(page: Frame | Page): Promise<string> {
+    return this.getTextContent(page, this.groupAccessErrorMessage);
   }
 }
 


### PR DESCRIPTION
### Description

Adds three helpers to the BO customer create/edit page object, needed by the companion PrestaShop core PR PrestaShop/PrestaShop#41688 (issue #35589), whose UI test asserts a customer cannot be saved without an access group:

- `uncheckAllGroupAccess(page)` — unchecks the visitor/guest/customer group checkboxes (reuses the existing group-access selectors and `setCheckedWithIcon`).
- `clickOnSaveButton(page)` — clicks Save **without** waiting for navigation, since failed validation keeps the page on the edit form.
- `getGroupAccessErrorMessage(page)` — returns the inline `.js-at-least-one-group-error` message text.

Companion to PrestaShop/PrestaShop#41688.

🤖 Generated with [Claude Code](https://claude.com/claude-code)