### PR TITLE
Add addCurrentPageToQuickAccessWithEmptyName for Quick Access modal inline validation

### DIFF
--- a/src/interfaces/BO/index.ts
+++ b/src/interfaces/BO/index.ts
@@ -81,6 +81,7 @@ export interface BOBasePagePageInterface extends CommonPageInterface {
   readonly webserviceLink: string;
 
   addCurrentPageToQuickAccess(page: Page, pageName: string): Promise<string | null>;
+  addCurrentPageToQuickAccessWithEmptyName(page: Page): Promise<string | null>;
   chooseShop(page: Page, shopNumber: number): Promise<void>;
   clickOnBreadCrumbLink(page: Page, link: string): Promise<void>;
   clickOnMultiStoreHeader(page: Page): Promise<void>;

--- a/src/pages/BO/BOBasePage.ts
+++ b/src/pages/BO/BOBasePage.ts
@@ -65,6 +65,8 @@ export default class BOBasePage extends CommonPage implements BOBasePagePageInte
 
   private readonly quickAccessAddModalSaveButton: string;
 
+  private readonly quickAccessAddModalNameError: string;
+
   private readonly navbarSearchInput: string;
 
   protected readonly helpButton: string;
@@ -349,6 +351,7 @@ export default class BOBasePage extends CommonPage implements BOBasePagePageInte
     this.quickAccessAddModal = '#quick-access-add-modal';
     this.quickAccessAddModalNameInput = `${this.quickAccessAddModal} #quick-access-name`;
     this.quickAccessAddModalSaveButton = `${this.quickAccessAddModal} #quick-access-save-btn`;
+    this.quickAccessAddModalNameError = `${this.quickAccessAddModal} #quick-access-name-error .js-error-text`;
     this.navbarSearchInput = '#bo_query';
 
     // Header links
@@ -772,6 +775,35 @@ export default class BOBasePage extends CommonPage implements BOBasePagePageInte
     }
 
     return page.locator(this.growlDiv).textContent();
+  }
+
+  /**
+   * Try to add the current page to quick access with an empty name and return the inline validation error.
+   * On PrestaShop ≤ 9.1.x the action still triggers the native window.prompt() (no modal): the prompt is
+   * dismissed and null is returned, since inline validation does not apply to the legacy flow.
+   * @param page {Page} Browser tab
+   * @returns {Promise<string|null>} The inline error text, or null when the modal is not available
+   */
+  async addCurrentPageToQuickAccessWithEmptyName(page: Page): Promise<string | null> {
+    // Dismiss the legacy window.prompt() (≤ 9.1.x) so the call never blocks
+    await this.dialogListener(page, false);
+    await this.waitForSelectorAndClick(page, this.quickAccessDropdownToggle);
+    await this.waitForSelectorAndClick(page, this.quickAddCurrentLink);
+
+    const isModalVisible = await page.locator(this.quickAccessAddModal)
+      .waitFor({state: 'visible', timeout: 2000})
+      .then(() => true)
+      .catch(() => false);
+
+    // No modal => legacy window.prompt() flow (≤ 9.1.x), inline validation does not apply
+    if (!isModalVisible) {
+      return null;
+    }
+
+    // Submit without a name: the modal must stay open and show an inline error
+    await this.waitForSelectorAndClick(page, this.quickAccessAddModalSaveButton);
+
+    return this.getTextContent(page, this.quickAccessAddModalNameError);
   }
 
   /**


### PR DESCRIPTION
## Context

Follow-up to [#992](https://github.com/PrestaShop/ui-testing-library/pull/992), which adapted `addCurrentPageToQuickAccess` to the new Quick Access modal introduced by [PrestaShop/PrestaShop#41608](https://github.com/PrestaShop/PrestaShop/pull/41608).

The modal now performs inline validation (AC-4 of the issue): submitting an empty shortcut name keeps the modal open and shows an inline error instead of silently doing nothing. A page-object method is needed so a core campaign can cover this behavior.

## Changes

**`src/pages/BO/BOBasePage.ts`**

- Added selector `#quick-access-add-modal #quick-access-name-error .js-error-text` for the inline name error
- Added `addCurrentPageToQuickAccessWithEmptyName(page)`:
  1. Opens the "Add current page to Quick Access" modal
  2. Clicks Save without filling the name
  3. Returns the inline error text shown in the still-open modal
- On PrestaShop <= 9.1.x there is no modal (native `window.prompt()`): the prompt is dismissed and `null` is returned so the caller can skip the assertion.

**`src/interfaces/BO/index.ts`**

- Declared the new method on `BOBasePagePageInterface`

## Merge order

This PR must be merged **before** the related core PR so that `tests/UI/package-lock.json` can be updated to pick up the new `#main` reference.

## Related PR

- PrestaShop/PrestaShop#41612
- Follows PrestaShop/ui-testing-library#992