### PR TITLE
Fix modal visibility check in BOWallOfFamePage

### DIFF
--- a/src/versions/develop/pages/BO/community/wallOfFame.ts
+++ b/src/versions/develop/pages/BO/community/wallOfFame.ts
@@ -198,7 +198,7 @@ class BOWallOfFamePage extends BOBasePage implements BOWallOfFamePageInterface {
    */
   async clickContributorActionButton(page: Page, contributorName: string): Promise<void> {
     await page.locator(`${this.topContributorsCard} tr:has-text("${contributorName}") button`).click();
-    await this.waitForVisibleSelector(page, this.contributorModal);
+    await this.waitForVisibleSelector(page, this.contributorModalCloseButton);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Fix `clickContributorActionButton`: wait for `.puik-modal__close` (close button) instead of `.puik-modal` (modal container)

The PUIK/HeadlessUI modal container (`.puik-modal`) is present in the DOM with `data-headlessui-state="open"` but is flagged as **hidden** by Playwright due to ancestor visibility inheritance during the CSS transition. Waiting for the close button inside the modal instead reliably detects when the modal is fully interactive.

## Related PRs

- Fixes UI test failure in https://github.com/PrestaShop/PrestaShop/pull/41686

## Test plan

Launch test `functional/BO/16_wallOfFame/03_topContributors.ts`