### PR TITLE
Fix contributor modal close button selector in BOWallOfFamePage

### DIFF
--- a/src/versions/develop/pages/BO/community/wallOfFame.ts
+++ b/src/versions/develop/pages/BO/community/wallOfFame.ts
@@ -107,7 +107,7 @@ class BOWallOfFamePage extends BOBasePage implements BOWallOfFamePageInterface {
     this.contributorModalName = `${this.contributorModal} .wof-contributor-modal__name`;
     this.contributorModalGitHubUsername = `${this.contributorModal} .wof-contributor-modal__username`;
     this.contributorModalAvatar = `${this.contributorModal} img.wof-contributor-modal__avatar`;
-    this.contributorModalCloseButton = `${this.contributorModal} .puik-modal__close`;
+    this.contributorModalCloseButton = `${this.contributorModal} .wof-top-modal__close-btn`;
   }
 
   /**


### PR DESCRIPTION
## Summary

- Fix `contributorModalCloseButton` selector: replace `.puik-modal__close` (PUIK default close button — does not exist in this modal) with `.wof-top-modal__close-btn` (the actual close button rendered in the Wall of Fame contributor modal)

The wrong selector caused `waitForVisibleSelector` to timeout in CI because it was waiting for an element that never appears in the DOM.

## Related PRs

- https://github.com/PrestaShop/PrestaShop/pull/41686

## Test plan

Launch test `functional/BO/16_wallOfFame/03_topContributors.ts`