### PR TITLE
Fix Wall of Fame contributor modal selectors

### DIFF
--- a/src/versions/develop/pages/BO/community/wallOfFame.ts
+++ b/src/versions/develop/pages/BO/community/wallOfFame.ts
@@ -104,9 +104,9 @@ class BOWallOfFamePage extends BOBasePage implements BOWallOfFamePageInterface {
 
     // Contributor modal (PUIK modal component)
     this.contributorModal = '.puik-modal';
-    this.contributorModalName = `${this.contributorModal} .wof-contributor-modal__name`;
-    this.contributorModalGitHubUsername = `${this.contributorModal} .wof-contributor-modal__username`;
-    this.contributorModalAvatar = `${this.contributorModal} img.wof-contributor-modal__avatar`;
+    this.contributorModalName = `${this.contributorModal} .wof-top-modal__title h3`;
+    this.contributorModalGitHubUsername = `${this.contributorModal} .wof-top-modal__title .tooltip__slot--wrapper`;
+    this.contributorModalAvatar = `${this.contributorModal} .wof-top-modal__avatar`;
     this.contributorModalCloseButton = `${this.contributorModal} .wof-top-modal__close-btn`;
   }
 


### PR DESCRIPTION
## Summary

- Fix `contributorModalName` selector: `.wof-contributor-modal__name` → `.wof-top-modal__title h3`
- Fix `contributorModalGitHubUsername` selector: `.wof-contributor-modal__username` → `.wof-top-modal__title .tooltip__slot--wrapper`
- Fix `contributorModalAvatar` selector: `img.wof-contributor-modal__avatar` → `.wof-top-modal__avatar`

## Test plan

- [ ] Run `03_topContributors.ts` — modal name, GitHub username and avatar should be found without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)