### PR TITLE
Fix Wall of Fame contributor modal username and avatar selectors

### DIFF
--- a/src/versions/develop/pages/BO/community/wallOfFame.ts
+++ b/src/versions/develop/pages/BO/community/wallOfFame.ts
@@ -105,8 +105,8 @@ class BOWallOfFamePage extends BOBasePage implements BOWallOfFamePageInterface {
     // Contributor modal (PUIK modal component)
     this.contributorModal = '.puik-modal';
     this.contributorModalName = `${this.contributorModal} .wof-top-modal__title h3`;
-    this.contributorModalGitHubUsername = `${this.contributorModal} .wof-top-modal__title .tooltip__slot--wrapper`;
-    this.contributorModalAvatar = `${this.contributorModal} .wof-top-modal__avatar`;
+    this.contributorModalGitHubUsername = `${this.contributorModal} .wof-top-modal__title .puik-tag p`;
+    this.contributorModalAvatar = `${this.contributorModal} .wof-top-modal__avatar img`;
     this.contributorModalCloseButton = `${this.contributorModal} .wof-top-modal__close-btn`;
   }
 


### PR DESCRIPTION
## Summary

- Fix `contributorModalGitHubUsername` selector: `.wof-top-modal__title .tooltip__slot--wrapper` → `.wof-top-modal__title .puik-tag p`
- Fix `contributorModalAvatar` selector: `.wof-top-modal__avatar` → `.wof-top-modal__avatar img`

## Test plan

- [ ] Run `03_topContributors.ts` — GitHub username and avatar should be found without timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)