### PR TITLE
Add getViewAllContributorsButtonUrl to BOWallOfFamePage

### DIFF
--- a/src/interfaces/BO/community/wallOfFame.ts
+++ b/src/interfaces/BO/community/wallOfFame.ts
@@ -10,6 +10,7 @@ export interface BOWallOfFamePageInterface extends BOBasePagePageInterface {
   clickNextNewContributorButton(page: Page): Promise<void>;
   clickPreviousNewContributorButton(page: Page): Promise<void>;
   clickViewAllContributorsButton(page: Page): Promise<Page>;
+  getViewAllContributorsButtonUrl(page: Page): Promise<string>;
   closeContributorModal(page: Page): Promise<void>;
   getContributionPercentage(page: Page, contributor: 'PrestaShop' | 'Community'): Promise<number>;
   getContributorModalGitHubUsername(page: Page): Promise<string>;

--- a/src/versions/develop/pages/BO/community/wallOfFame.ts
+++ b/src/versions/develop/pages/BO/community/wallOfFame.ts
@@ -101,7 +101,7 @@ class BOWallOfFamePage extends BOBasePage implements BOWallOfFamePageInterface {
     this.topContributorsCardTitle = `${this.topContributorsCard} .wof-top-card__title`;
     this.topContributorsDescription = `${this.topContributorsCard} .wof-top-card__description`;
     this.topContributorsTableHeaders = `${this.topContributorsCard} .puik-table__head__row__item`;
-    this.viewAllContributorsButton = `${this.topContributorsCard} .wof-top-card__footer a`;
+    this.viewAllContributorsButton = `${this.topContributorsCard} .wof-top-card__external-link a`;
 
     // New Contributors section
     this.newContributorsSection = '.wof-new-contributors-section';

--- a/src/versions/develop/pages/BO/community/wallOfFame.ts
+++ b/src/versions/develop/pages/BO/community/wallOfFame.ts
@@ -285,6 +285,13 @@ class BOWallOfFamePage extends BOBasePage implements BOWallOfFamePageInterface {
   }
 
   /**
+   * Get the href attribute of the "View all" button without clicking it
+   */
+  async getViewAllContributorsButtonUrl(page: Page): Promise<string> {
+    return (await page.locator(this.viewAllContributorsButton).getAttribute('href')) ?? '';
+  }
+
+  /**
    * Get the New Contributors section title
    */
   async getNewContributorsSectionTitle(page: Page): Promise<string> {


### PR DESCRIPTION
## Summary

- Add `getViewAllContributorsButtonUrl(page)` method to `BOWallOfFamePage`: reads the `href` attribute of the "View all" contributors button without clicking it
- Add the method signature to `BOWallOfFamePageInterface`

## Why

`clickViewAllContributorsButton` uses `openLinkWithTargetBlank` which waits for a `popup` event. The button does not open a new tab (`target="_blank"`), so the event never fires and the test times out. Reading the `href` directly is a reliable alternative.

## Test plan

- [ ] Run `03_topContributors.ts` — "check the View all button URL" step should pass without timeout

