### PR TITLE
TEST-749 - Add orderMessage support to FakerOrder and createOrder

### DIFF
--- a/src/data/faker/order.ts
+++ b/src/data/faker/order.ts
@@ -45,6 +45,8 @@ export default class FakerOrder {
 
   public readonly deliveryOption: OrderDeliveryOption;
 
+  public readonly orderMessage: string;
+
   /**
      * Constructor for class Order
      * @param orderToCreate {OrderCreator} Could be used to force the value of some members
@@ -99,6 +101,9 @@ export default class FakerOrder {
       name: '',
       freeShipping: false,
     };
+
+    /** @type {string} */
+    this.orderMessage = orderToCreate.orderMessage || '';
   }
 
   /**

--- a/src/data/faker/order.ts
+++ b/src/data/faker/order.ts
@@ -103,7 +103,7 @@ export default class FakerOrder {
     };
 
     /** @type {string} */
-    this.orderMessage = orderToCreate.orderMessage || '';
+    this.message = orderToCreate.message || '';
   }
 
   /**

--- a/src/data/faker/order.ts
+++ b/src/data/faker/order.ts
@@ -45,7 +45,7 @@ export default class FakerOrder {
 
   public readonly deliveryOption: OrderDeliveryOption;
 
-  public readonly orderMessage: string;
+  public readonly message: string;
 
   /**
      * Constructor for class Order

--- a/src/data/types/order.ts
+++ b/src/data/types/order.ts
@@ -20,7 +20,7 @@ type OrderCreator = {
     discountGiftValue?: number
     totalPrice?: number
     deliveryOption?: OrderDeliveryOption
-    orderMessage?: string
+    message?: string
 }
 
 type OrderDeliveryOption = {

--- a/src/data/types/order.ts
+++ b/src/data/types/order.ts
@@ -20,6 +20,7 @@ type OrderCreator = {
     discountGiftValue?: number
     totalPrice?: number
     deliveryOption?: OrderDeliveryOption
+    orderMessage?: string
 }
 
 type OrderDeliveryOption = {

--- a/src/versions/develop/pages/BO/orders/create.ts
+++ b/src/versions/develop/pages/BO/orders/create.ts
@@ -1308,6 +1308,11 @@ class BOOrderCreatePage extends BOBasePage implements BOOrdersCreatePageInterfac
     // Set order status
     await this.setOrderStatus(page, orderToMake.status);
 
+    // Set order message if provided
+    if (orderToMake.orderMessage) {
+      await this.setOrderMessage(page, orderToMake.orderMessage);
+    }
+
     // Create the order
     await this.clickAndWaitForURL(page, this.createOrderButton);
   }

--- a/src/versions/develop/pages/BO/orders/create.ts
+++ b/src/versions/develop/pages/BO/orders/create.ts
@@ -1311,7 +1311,8 @@ class BOOrderCreatePage extends BOBasePage implements BOOrdersCreatePageInterfac
     // Set order message if provided
     if (orderToMake.orderMessage) {
       await this.setOrderMessage(page, orderToMake.orderMessage);
-    }
+    if (orderToMake.message) {
+      await this.setOrderMessage(page, orderToMake.message);
 
     // Create the order
     await this.clickAndWaitForURL(page, this.createOrderButton);

--- a/src/versions/develop/pages/BO/orders/create.ts
+++ b/src/versions/develop/pages/BO/orders/create.ts
@@ -1308,11 +1308,9 @@ class BOOrderCreatePage extends BOBasePage implements BOOrdersCreatePageInterfac
     // Set order status
     await this.setOrderStatus(page, orderToMake.status);
 
-    // Set order message if provided
-    if (orderToMake.orderMessage) {
-      await this.setOrderMessage(page, orderToMake.orderMessage);
     if (orderToMake.message) {
       await this.setOrderMessage(page, orderToMake.message);
+    }
 
     // Create the order
     await this.clickAndWaitForURL(page, this.createOrderButton);


### PR DESCRIPTION
## Summary
- Add `orderMessage` optional field to `OrderCreator` type and `FakerOrder` class
- Update `createOrder()` method to call `setOrderMessage()` before clicking create if a message is provided

## Test plan
- [ ] Verify `FakerOrder` accepts `orderMessage` field
- [ ] Verify `createOrder()` sets the order message when provided
- [ ] Run `03_createSimpleOrderInBO.ts` test to confirm order message is set and verified
