### PR TITLE
`boCategoriesCreatePage` : Fixed setValueOnTinymceInput for PSClassic

### DIFF
--- a/src/versions/develop/pages/BO/catalog/brands/create.ts
+++ b/src/versions/develop/pages/BO/catalog/brands/create.ts
@@ -71,6 +71,9 @@ class BOBrandsCreatePage extends BOBasePage implements BOBrandsCreatePageInterfa
    * @returns {Promise<string>}
    */
   async createEditBrand(page: Page, brandData: FakerBrand): Promise<string> {
+    // Wait for the TinyMCE is visible
+    await this.waitForVisibleSelector(page, this.shortDescriptionIFrame(1), 30000);
+    await this.waitForVisibleSelector(page, this.descriptionIFrame(1), 30000);
     // Fill Name
     await this.setValue(page, this.nameInput, brandData.name);
     // Fill information in english

--- a/src/versions/develop/pages/BO/catalog/categories/create.ts
+++ b/src/versions/develop/pages/BO/catalog/categories/create.ts
@@ -131,6 +131,9 @@ class BOCategoriesCreatePage extends BOBasePage implements BOCategoriesCreatePag
    * @returns {Promise<string>}
    */
   async createEditCategory(page: Page, categoryData: FakerCategory): Promise<string> {
+    // Wait for the TinyMCE is visible
+    await this.waitForVisibleSelector(page, this.descriptionIframeEn, 30000);
+
     await this.setValue(page, this.nameInputEn, categoryData.name);
     await this.setChecked(page, this.displayedToggleInput(categoryData.displayed ? 1 : 0));
     await this.setValueOnTinymceInput(page, this.descriptionIframeEn, categoryData.description);
@@ -162,6 +165,9 @@ class BOCategoriesCreatePage extends BOBasePage implements BOCategoriesCreatePag
    * @returns {Promise<string>}
    */
   async editHomeCategory(page: Page, categoryData: FakerCategory): Promise<string> {
+    // Wait for the TinyMCE is visible
+    await this.waitForVisibleSelector(page, this.rootCategoryDescriptionIframe, 30000);
+
     await this.setValue(page, this.rootCategoryNameInput, categoryData.name);
     await this.setChecked(page, this.rootCategoryDisplayedToggleInput(categoryData.displayed ? 1 : 0));
     await this.setValueOnTinymceInput(page, this.rootCategoryDescriptionIframe, categoryData.description);

--- a/src/versions/develop/pages/BO/catalog/suppliers/create.ts
+++ b/src/versions/develop/pages/BO/catalog/suppliers/create.ts
@@ -144,6 +144,8 @@ class BOSuppliersCreatePage extends BOBasePage implements BOSuppliersCreatePageI
 
     // Fill Description, meta title, meta description and meta keywords in english
     await this.changeLanguageForSelectors(page, 'en');
+    // Wait for the TinyMCE is visible
+    await this.waitForVisibleSelector(page, this.descriptionIFrame(1), 30000);
     await this.setValueOnTinymceInput(page, this.descriptionIFrame(1), supplierData.description);
     await this.setValue(page, this.metaTitleInput(1), supplierData.metaTitle);
     await this.setValue(page, this.metaDescriptionTextarea(1), supplierData.metaDescription);

--- a/src/versions/develop/pages/BO/design/pages/create.ts
+++ b/src/versions/develop/pages/BO/design/pages/create.ts
@@ -68,6 +68,8 @@ class BOCMSPagesCreatePage extends BOBasePage implements BOCMSPagesCreatePageInt
     await this.setValue(page, this.titleInput, pageData.title);
     await this.setValue(page, this.metaTitleInput, pageData.metaTitle);
     await this.setValue(page, this.metaDescriptionInput, pageData.metaDescription);
+    // Wait for the TinyMCE is visible
+    await this.waitForVisibleSelector(page, this.pageContentIframe, 30000);
     await this.setValueOnTinymceInput(page, this.pageContentIframe, pageData.content);
     await this.setChecked(page, this.indexationToggleInput(pageData.indexation ? 1 : 0));
     await this.setChecked(page, this.displayedToggleInput(pageData.displayed ? 1 : 0));


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | main
| Description?      | `boCategoriesCreatePage` : Fixed setValueOnTinymceInput for PSClassic
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is :green_circle: 
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp