### PR TITLE
Fix quick access grid cell selectors on <= 9.1.x (legacy HelperList)

### DIFF
--- a/src/versions/9.1/pages/BO/quickAccess/index.ts
+++ b/src/versions/9.1/pages/BO/quickAccess/index.ts
@@ -23,6 +23,22 @@ class BOQuickAccessPage extends BOQuickAccessPageVersion implements BOQuickAcces
     this.filterSearchButton = '#submitFilterButtonquick_access';
     this.filterResetButton = 'button[name=\'submitResetquick_access\']';
 
+    // Table body selectors
+    // The parent (develop) page object derives these from the Symfony grid table (#quick_access_grid_table),
+    // which does not exist on <= 9.1.x (legacy HelperList #table-quick_access). Re-derive them here so that
+    // getTextColumn() targets the legacy table. Column order matches the legacy fields_list
+    // (checkbox, id_quick_access, name, link, new_window), i.e. the same nth-child as the develop grid.
+    this.tableBody = `${this.gridTable} tbody`;
+    this.tableBodyRows = `${this.tableBody} tr`;
+    this.tableBodyRow = (row: number) => `${this.tableBodyRows}:nth-child(${row})`;
+    this.tableBodyColumn = (row: number) => `${this.tableBodyRow(row)} td`;
+
+    // Columns selectors
+    this.tableColumnId = (row: number) => `${this.tableBodyColumn(row)}:nth-child(2)`;
+    this.tableColumnName = (row: number) => `${this.tableBodyColumn(row)}:nth-child(3)`;
+    this.tableColumnLink = (row: number) => `${this.tableBodyColumn(row)}:nth-child(4)`;
+    this.tableColumnIsNewWindow = (row: number) => `${this.tableBodyColumn(row)}:nth-child(5)`;
+
     // Bulk actions selectors
     this.bulkActionBlock = 'div.bulk-actions';
     this.bulkActionMenuButton = '#bulk_action_menu_quick_access';

--- a/src/versions/develop/pages/BO/quickAccess/index.ts
+++ b/src/versions/develop/pages/BO/quickAccess/index.ts
@@ -26,21 +26,21 @@ class BOQuickAccessPage extends BOBasePage implements BOQuickAccessInterface {
 
   protected filterResetButton: string;
 
-  private readonly tableBody: string;
+  protected tableBody: string;
 
-  private readonly tableBodyRows: string;
+  protected tableBodyRows: string;
 
-  private readonly tableBodyRow: (row: number) => string;
+  protected tableBodyRow: (row: number) => string;
 
-  private readonly tableBodyColumn: (row: number) => string;
+  protected tableBodyColumn: (row: number) => string;
 
-  private readonly tableColumnId: (row: number) => string;
+  protected tableColumnId: (row: number) => string;
 
-  private readonly tableColumnName: (row: number) => string;
+  protected tableColumnName: (row: number) => string;
 
-  private readonly tableColumnLink: (row: number) => string;
+  protected tableColumnLink: (row: number) => string;
 
-  private readonly tableColumnIsNewWindow: (row: number) => string;
+  protected tableColumnIsNewWindow: (row: number) => string;
 
   protected bulkActionBlock: string;
 


### PR DESCRIPTION
## Context

`functional/BO/15_header/02_quickAccess` fails on **9.1.x** (and any ≤ 9.1.x branch) at the step *should filter quick access table by link name*: `page.waitForSelector` times out (10s) on `#quick_access_grid_table tbody tr:nth-child(1) td:nth-child(3)`.

## Root cause

`src/versions/9.1/pages/BO/quickAccess` extends `src/versions/develop/...`, which derives its table-body and column selectors **in the develop constructor** from the Symfony grid table `#quick_access_grid_table`, declared as `private readonly`.

On ≤ 9.1.x the *Manage quick access* page is still the **legacy HelperList** (`#table-quick_access`, served by `AdminQuickAccessesController`). The 9.1 override correctly switches `gridTable` and the **filter** selectors to the legacy table — but it could **not** re-derive the **cell** selectors (`tableColumn*`, `tableBody*`) because they were `private readonly` in develop. So `getTextColumn()` keeps targeting `#quick_access_grid_table…`, which does not exist on 9.1.x → timeout.

## Changes

- **`versions/develop`**: widen `tableBody` / `tableBodyRows` / `tableBodyRow` / `tableBodyColumn` and the `tableColumn*` selectors from `private readonly` to `protected` so version overrides can re-derive them. **No behaviour change on develop.**
- **`versions/9.1`**: re-derive the table-body and column selectors from the legacy `gridTable`. Column order matches the legacy `fields_list` (checkbox, `id_quick_access`, `name`, `link`, `new_window`) — i.e. the same `nth-child(2/3/4/5)` as the develop grid. Verified against the core `admin-dev` HelperList templates (`list_header.tpl`: `tr.filter` lives in `<thead>`, so `tbody tr:nth-child(1)` is the first data row; `list_content.tpl`: checkbox is `td:nth-child(1)`, fields follow in order).

## How to test

Run the `functional:BO:header` campaign via [ga.tests.ui.pr](https://github.com/PrestaShop/ga.tests.ui.pr/) with `base_branch: 9.1.x`. The `02_quickAccess` campaign — in particular *should filter quick access table by link name* — must stay green.

## Notes

- Independent of PrestaShop/ui-testing-library#1010; this is a pre-existing bug exposed once the develop quick access page object moved to the Symfony grid.
- The earlier core-side attempt to stabilise this step (PrestaShop/PrestaShop#41755, "close the tab") was a misdiagnosis and does not fix it; this PR addresses the real cause.