### PR TITLE
Fix addCurrentPageToQuickAccessWithEmptyName: clear pre-filled name before submit

### DIFF
--- a/src/pages/BO/BOBasePage.ts
+++ b/src/pages/BO/BOBasePage.ts
@@ -800,7 +800,8 @@ export default class BOBasePage extends CommonPage implements BOBasePagePageInte
       return null;
     }
 
-    // Submit without a name: the modal must stay open and show an inline error
+    // Clear any pre-filled name, then submit: the modal must stay open and show an inline error
+    await page.locator(this.quickAccessAddModalNameInput).fill('');
     await this.waitForSelectorAndClick(page, this.quickAccessAddModalSaveButton);
 
     return this.getTextContent(page, this.quickAccessAddModalNameError);


### PR DESCRIPTION
## Summary

- The Quick Access modal pre-fills the name input with the current page title (via `data-link`).
- `addCurrentPageToQuickAccessWithEmptyName` was clicking Save without first clearing the field, so the pre-filled name was submitted and the empty-name validation was never triggered.
- Add `page.locator(this.quickAccessAddModalNameInput).fill('')` before clicking Save so the method reliably tests the empty-name error path.

## Test plan

- [ ] Run `functional:BO:header` UI campaign — the `should reload, try to add the current page with an empty name and check the inline error` step must pass.