### PR TITLE
`boStockPage` : Added waitForResponse with big timeout (bcz PSClassic is so slow)

### DIFF
--- a/src/versions/develop/pages/BO/catalog/attributes/view.ts
+++ b/src/versions/develop/pages/BO/catalog/attributes/view.ts
@@ -304,7 +304,7 @@ class BOAttributesViewPage extends BOBasePage implements BOAttributesViewPageInt
   async changePosition(page: Page, actualPosition: number, newPosition: number): Promise<string|null> {
     await this.dragAndDropSlowly(page, this.tableColumnHandle(actualPosition), this.tableBodyRow(newPosition));
 
-    return this.getAlertSuccessBlockParagraphContent(page);
+    return this.getAlertSuccessBlockParagraphContent(page, 30000);
   }
 
   /* Bulk actions methods */

--- a/src/versions/develop/pages/BO/catalog/stock/index.ts
+++ b/src/versions/develop/pages/BO/catalog/stock/index.ts
@@ -1,6 +1,6 @@
 import {type BOStockPageInterface} from '@interfaces/BO/catalog/stock';
 import BOBasePage from '@pages/BO/BOBasePage';
-import {type Page} from '@playwright/test';
+import {type Page, type Response} from '@playwright/test';
 
 /**
  * stocks page, contains functions that can be used on the page
@@ -196,9 +196,9 @@ class BOStocksPage extends BOBasePage implements BOStockPageInterface {
   async goToSubTabMovements(page: Page): Promise<void> {
     await page.locator(this.movementsNavItemLink).click();
     await Promise.all([
-      page.waitForResponse('**/api/stock-movements/employees**'),
-      page.waitForResponse('**/api/stock-movements/types**'),
-      page.waitForResponse('**/api/stock-movements/**'),
+      page.waitForResponse('**/api/stock-movements/employees?**'),
+      page.waitForResponse('**/api/stock-movements/types?**'),
+      page.waitForResponse('**/api/stock-movements/?**'),
     ]);
     await this.waitForVisibleSelector(page, `${this.movementsNavItemLink}.active`, 2000);
   }
@@ -531,6 +531,14 @@ class BOStocksPage extends BOBasePage implements BOStockPageInterface {
 
     // Wait for check button before click
     await page.locator(this.applyNewQuantityButton).click();
+
+    // Wait for response
+    await page.waitForResponse(
+      (response: Response) => response.url().includes('api/stocks/products'),
+      {
+        timeout: 60000,
+      },
+    );
 
     // Wait for alert-Box after update quantity and close alert-Box
     await this.waitForVisibleSelector(page, this.alertBoxTextSpan, 30000);


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project!

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests

For type and category see:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/pull-requests/#type--category
------------------------------------------------------------------------------>

| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | main
| Description?      | `boStockPage` : Added waitForResponse with big timeout (bcz PSClassic is so slow)
| Type?             | improvement
| Category?         | TE
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | CI is :green_circle: 
| Fixed issue or discussion?     | N/A
| Related PRs       | N/A
| Sponsor company   | @PrestaShopCorp