### PR TITLE
Add featureFlagExperimentalEndpoints to BOFeatureFlag

### DIFF
--- a/src/interfaces/BO/advancedParameters/featureFlag.ts
+++ b/src/interfaces/BO/advancedParameters/featureFlag.ts
@@ -5,6 +5,7 @@ export interface BOFeatureFlagInterface extends BOBasePagePageInterface {
   readonly featureFlagAdminAPI: string;
   readonly featureFlagAdminAPIMultistore: string;
   readonly featureFlagDiscount: string;
+  readonly featureFlagExperimentalEndpoints: string;
   readonly featureFlagImprovedShipment: string;
   readonly featureFlagProductPageV2: string;
   readonly pageTitle: string;

--- a/src/versions/develop/pages/BO/advancedParameters/featureFlag.ts
+++ b/src/versions/develop/pages/BO/advancedParameters/featureFlag.ts
@@ -20,6 +20,8 @@ class BOFeatureFlag extends BOBasePage implements BOFeatureFlagInterface {
 
   public readonly featureFlagDiscount: string;
 
+  public readonly featureFlagExperimentalEndpoints: string;
+
   public readonly featureFlagMultipleImageFormats: string;
 
   private readonly featureFlagSwitchButton: (status: string, feature: string, toggle: number) => string;
@@ -47,6 +49,7 @@ class BOFeatureFlag extends BOBasePage implements BOFeatureFlagInterface {
     this.featureFlagMultipleImageFormats = 'multiple_image_format';
     this.featureFlagAdminAPI = 'admin_api';
     this.featureFlagAdminAPIMultistore = 'admin_api_multistore';
+    this.featureFlagExperimentalEndpoints = 'admin_api_experimental_endpoints';
     this.featureFlagImprovedShipment = 'improved_shipment';
     this.featureFlagDiscount = 'discount';
     // Selectors
@@ -81,6 +84,9 @@ class BOFeatureFlag extends BOBasePage implements BOFeatureFlagInterface {
         isStable = false;
         break;
       case this.featureFlagDiscount:
+        isStable = false;
+        break;
+      case this.featureFlagExperimentalEndpoints:
         isStable = false;
         break;
       default:


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Adds the `admin_api_experimental_endpoints` feature flag constant to support enabling experimental Admin API endpoints in UI tests.
| Type?             | new feature
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | PrestaShop SA
| How to test?      | CI is green 