### PR TITLE
Add filterByFileSize() helper to the BO Files page object

### DIFF
--- a/src/interfaces/BO/catalog/files/index.ts
+++ b/src/interfaces/BO/catalog/files/index.ts
@@ -6,6 +6,7 @@ export interface BOFilesPageInterface extends BOBasePagePageInterface {
 
   deleteFile(page: Page, row?: number): Promise<string>;
   deleteFilesBulkActions(page: Page): Promise<string>;
+  filterByFileSize(page: Page, min: number|string, max: number|string): Promise<void>;
   filterTable(page: Page, filterBy: string, value?: string): Promise<void>;
   getAllRowsColumnContent(page: Page, column: string): Promise<string[]>;
   getNumberOfElementInGrid(page: Page): Promise<number>;

--- a/src/versions/develop/pages/BO/catalog/files/index.ts
+++ b/src/versions/develop/pages/BO/catalog/files/index.ts
@@ -20,6 +20,10 @@ class BOFilesPage extends BOBasePage implements BOFilesPageInterface {
 
   private readonly filterColumn: (filterBy: string) => string;
 
+  private readonly filterFileSizeMinInput: string;
+
+  private readonly filterFileSizeMaxInput: string;
+
   private readonly filterSearchButton: string;
 
   private readonly filterResetButton: string;
@@ -87,6 +91,8 @@ class BOFilesPage extends BOBasePage implements BOFilesPageInterface {
 
     // Filters
     this.filterColumn = (filterBy: string) => `${this.gridTable} #attachment_${filterBy}`;
+    this.filterFileSizeMinInput = `${this.gridTable} #attachment_file_size_min_field`;
+    this.filterFileSizeMaxInput = `${this.gridTable} #attachment_file_size_max_field`;
     this.filterSearchButton = `${this.gridTable} .grid-search-button`;
     this.filterResetButton = `${this.gridTable} .grid-reset-button`;
 
@@ -237,6 +243,19 @@ class BOFilesPage extends BOBasePage implements BOFilesPageInterface {
   async filterTable(page: Page, filterBy: string, value: string = ''): Promise<void> {
     await this.setValue(page, this.filterColumn(filterBy), value);
     // click on search
+    await this.clickAndWaitForURL(page, this.filterSearchButton);
+  }
+
+  /**
+   * Filter Files by size (bytes) using the min/max range inputs
+   * @param page {Page} Browser tab
+   * @param min {number|string} Minimum size in bytes (empty string to leave unset)
+   * @param max {number|string} Maximum size in bytes (empty string to leave unset)
+   * @return {Promise<void>}
+   */
+  async filterByFileSize(page: Page, min: number|string, max: number|string): Promise<void> {
+    await page.locator(this.filterFileSizeMinInput).fill(min.toString());
+    await page.locator(this.filterFileSizeMaxInput).fill(max.toString());
     await this.clickAndWaitForURL(page, this.filterSearchButton);
   }
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | main
| Description?      | Adds a `filterByFileSize(page, min, max)` helper on the BO Files page object. It fills the new `#attachment_file_size_min_field` / `#attachment_file_size_max_field` range inputs and submits the filter form.
| Type?             | new feature
| Category?         | BO
| BC breaks?        | no
| Deprecations?     | no
| Fixed issue or discussion?     | Companion to [PrestaShop/PrestaShop#41634](https://github.com/PrestaShop/PrestaShop/pull/41634) (fixes #11054)
| Related PRs       | PrestaShop/PrestaShop#41634
| Sponsor company   |

### Why

PrestaShop/PrestaShop#41634 replaces the broken single-value `LIKE` filter on the BO Files grid `file_size` column with a min/max byte range (`IntegerMinMaxFilterType`), the same pattern the Product grid already uses for quantity/price. The `03_catalog/06_files/03_filterSortPaginationAndBulkActions` campaign is updated there to drive the new range and needs a page-object helper for the two new inputs.

Once this is released and bumped in the core repo, the core PR's UI tests will go green.