### PR TITLE
fix: resolve the create-product iframe from its element instead of its URL

### DIFF
--- a/src/versions/develop/pages/BO/catalog/products/index.ts
+++ b/src/versions/develop/pages/BO/catalog/products/index.ts
@@ -365,6 +365,23 @@ class ProductsPage extends BOBasePage implements BOProductsPageInterface {
   }
 
   /**
+   * Resolve the "create product" iframe from its DOM element instead of matching its URL.
+   * `page.frame({url})` resolves against the frames the browser has already registered, so right
+   * after the modal opens it can still return null - firefox hits this far more often than
+   * chromium - and every caller then failed on `expect(createProductFrame).not.toBeNull()`.
+   * Waiting for the iframe element and taking its contentFrame() is deterministic.
+   * @param page {Page} Browser tab
+   * @returns {Promise<Frame>}
+   */
+  async getCreateProductFrame(page: Page): Promise<Frame> {
+    const frameElement = await page.waitForSelector(this.modalCreateProductIframe);
+    const createProductFrame: Frame | null = await frameElement.contentFrame();
+    expect(createProductFrame).not.toBeNull();
+
+    return createProductFrame!;
+  }
+
+  /**
    * Check if new product modal is visible
    * @param page {Page} Browser tab
    * @returns {Promise<boolean>}
@@ -373,8 +390,7 @@ class ProductsPage extends BOBasePage implements BOProductsPageInterface {
     await this.waitForVisibleSelector(page, `${this.modalCreateProduct} iframe`);
     await this.waitForHiddenSelector(page, this.modalCreateProductLoader);
 
-    const createProductFrame: Frame | null = page.frame({url: this.newProductIframeURL});
-    expect(createProductFrame).not.toBeNull();
+    const createProductFrame: Frame = await this.getCreateProductFrame(page);
 
     return this.elementVisible(createProductFrame!, this.addNewProductButton, 2000);
   }
@@ -410,8 +426,7 @@ class ProductsPage extends BOBasePage implements BOProductsPageInterface {
     await this.waitForVisibleSelector(page, `${this.modalCreateProduct} iframe`);
     await this.waitForHiddenSelector(page, this.modalCreateProductLoader);
 
-    const createProductFrame: Frame | null = page.frame({url: this.newProductIframeURL});
-    expect(createProductFrame).not.toBeNull();
+    const createProductFrame: Frame = await this.getCreateProductFrame(page);
 
     return this.getTextContent(createProductFrame!, this.productTypeDescription);
   }
@@ -436,8 +451,7 @@ class ProductsPage extends BOBasePage implements BOProductsPageInterface {
     await this.waitForHiddenSelector(page, this.modalCreateProductLoader);
     await this.waitForVisibleLocator(page.frameLocator(this.modalCreateProductIframe).locator(this.productType(productType)));
 
-    const createProductFrame: Frame | null = page.frame({url: this.newProductIframeURL});
-    expect(createProductFrame).not.toBeNull();
+    const createProductFrame: Frame = await this.getCreateProductFrame(page);
 
     await createProductFrame!.locator(this.productType(productType)).first().click();
   }
@@ -460,8 +474,7 @@ class ProductsPage extends BOBasePage implements BOProductsPageInterface {
    * @returns {Promise<void>}
    */
   async clickOnAddNewProduct(page: Page): Promise<void> {
-    const createProductFrame: Frame | null = page.frame({url: this.newProductIframeURL});
-    expect(createProductFrame).not.toBeNull();
+    const createProductFrame: Frame = await this.getCreateProductFrame(page);
 
     await this.waitForSelectorAndClick(createProductFrame!, this.addNewProductButton);
     await this.waitForHiddenSelector(page, this.modalCreateProductIframe, 30000);

--- a/src/versions/develop/pages/BO/catalog/products/index.ts
+++ b/src/versions/develop/pages/BO/catalog/products/index.ts
@@ -365,15 +365,11 @@ class ProductsPage extends BOBasePage implements BOProductsPageInterface {
   }
 
   /**
-   * Resolve the "create product" iframe from its DOM element instead of matching its URL.
-   * `page.frame({url})` resolves against the frames the browser has already registered, so right
-   * after the modal opens it can still return null - firefox hits this far more often than
-   * chromium - and every caller then failed on `expect(createProductFrame).not.toBeNull()`.
-   * Waiting for the iframe element and taking its contentFrame() is deterministic.
+   * Get the create product frame
    * @param page {Page} Browser tab
    * @returns {Promise<Frame>}
    */
-  async getCreateProductFrame(page: Page): Promise<Frame> {
+  private async getProductCreateFrame(page: Page): Promise<Frame> {
     const frameElement = await page.waitForSelector(this.modalCreateProductIframe);
     const createProductFrame: Frame | null = await frameElement.contentFrame();
     expect(createProductFrame).not.toBeNull();
@@ -390,7 +386,7 @@ class ProductsPage extends BOBasePage implements BOProductsPageInterface {
     await this.waitForVisibleSelector(page, `${this.modalCreateProduct} iframe`);
     await this.waitForHiddenSelector(page, this.modalCreateProductLoader);
 
-    const createProductFrame: Frame = await this.getCreateProductFrame(page);
+    const createProductFrame: Frame = await this.getProductCreateFrame(page);
 
     return this.elementVisible(createProductFrame!, this.addNewProductButton, 2000);
   }
@@ -426,7 +422,7 @@ class ProductsPage extends BOBasePage implements BOProductsPageInterface {
     await this.waitForVisibleSelector(page, `${this.modalCreateProduct} iframe`);
     await this.waitForHiddenSelector(page, this.modalCreateProductLoader);
 
-    const createProductFrame: Frame = await this.getCreateProductFrame(page);
+    const createProductFrame: Frame = await this.getProductCreateFrame(page);
 
     return this.getTextContent(createProductFrame!, this.productTypeDescription);
   }
@@ -451,7 +447,7 @@ class ProductsPage extends BOBasePage implements BOProductsPageInterface {
     await this.waitForHiddenSelector(page, this.modalCreateProductLoader);
     await this.waitForVisibleLocator(page.frameLocator(this.modalCreateProductIframe).locator(this.productType(productType)));
 
-    const createProductFrame: Frame = await this.getCreateProductFrame(page);
+    const createProductFrame: Frame = await this.getProductCreateFrame(page);
 
     await createProductFrame!.locator(this.productType(productType)).first().click();
   }
@@ -474,7 +470,7 @@ class ProductsPage extends BOBasePage implements BOProductsPageInterface {
    * @returns {Promise<void>}
    */
   async clickOnAddNewProduct(page: Page): Promise<void> {
-    const createProductFrame: Frame = await this.getCreateProductFrame(page);
+    const createProductFrame: Frame = await this.getProductCreateFrame(page);
 
     await this.waitForSelectorAndClick(createProductFrame!, this.addNewProductButton);
     await this.waitForHiddenSelector(page, this.modalCreateProductIframe, 30000);


### PR DESCRIPTION
## Problem

`Sanity (8.5, firefox, mysql)` is a required check on PrestaShop core and it keeps failing on one spec, always with the same assertion:

```
1) BO - Catalog - Products : Delete products with bulk actions
     Create second product
       should choose 'Standard product':
   Error: expect(received).not.toBeNull()
   Received: null
```

The `not.toBeNull()` is not in the core spec, it is in this library: `ProductsPage` resolves the "create product" iframe with

```ts
const createProductFrame: Frame | null = page.frame({url: this.newProductIframeURL});
expect(createProductFrame).not.toBeNull();
```

`page.frame({url})` matches against the frames the browser has already registered. Right after the modal opens that list can still be empty for this iframe, so the lookup returns `null` and the assertion fails. It is a race, not a missing element: the preceding lines already waited for the iframe and its content via `waitForVisibleSelector` / `frameLocator`, the same commit passes on a plain re-run, and the chromium variants of the very same runs pass. Firefox loses the race far more often.

## What this changes

Resolve the frame from its DOM element instead of matching its URL:

```ts
const frameElement = await page.waitForSelector(this.modalCreateProductIframe);
const createProductFrame: Frame | null = await frameElement.contentFrame();
```

`waitForSelector` waits for the iframe to exist and `contentFrame()` returns that element's own frame, so there is nothing to race against. It is factored into `getCreateProductFrame()` and used by the four methods that had the identical lookup: `isNewProductModalVisibleInFrame`, `getProductDescription`, `selectProductType` and `clickOnAddNewProduct`. The last two are the ones on the failing path, since `chooseProductType()` calls both.

The `Frame` return type is kept, so the existing helper calls (`elementVisible`, `getTextContent`, `waitForSelectorAndClick`) are untouched. `hasProductType()` in the same class already avoided the URL lookup and worked, which is the pattern this aligns with.

## Testing

`npm run lint` and `npm run build` pass locally.

I could not run the core UI campaigns against this branch: the runner I have available tests PrestaShop core PRs against the published `@prestashop-core/ui-testing` package, not a library branch, so this needs a UI run on your side to confirm the firefox occurrences stop.

Context: PrestaShop/PrestaShop#42072 tracks the failing check, with the affected runs listed. At the time of writing 15 open core PRs are blocked by this one check, and the same job is also red on recent `9.1.x` and `develop` sanity runs for unrelated merge commits.
